### PR TITLE
Fix assign_track_ids function for the graph

### DIFF
--- a/src/tracksdata/graph/_rustworkx_graph.py
+++ b/src/tracksdata/graph/_rustworkx_graph.py
@@ -1011,7 +1011,6 @@ class RustWorkXGraph(BaseGraph):
 
     def assign_track_ids(
         self,
-        track_id_offset: int = 1,
         output_key: str = DEFAULT_ATTR_KEYS.TRACK_ID,
         reset: bool = True,
         track_id_offset: int = 1,
@@ -1021,8 +1020,6 @@ class RustWorkXGraph(BaseGraph):
 
         Parameters
         ----------
-        track_id_offset : int
-            The starting track id, useful when assigning track ids to a subgraph.
         output_key : str
             The key of the output track id attribute.
         reset : bool

--- a/src/tracksdata/graph/_rustworkx_graph.py
+++ b/src/tracksdata/graph/_rustworkx_graph.py
@@ -1011,6 +1011,7 @@ class RustWorkXGraph(BaseGraph):
 
     def assign_track_ids(
         self,
+        track_id_offset: int = 1,
         output_key: str = DEFAULT_ATTR_KEYS.TRACK_ID,
         reset: bool = True,
     ) -> rx.PyDiGraph:
@@ -1019,6 +1020,8 @@ class RustWorkXGraph(BaseGraph):
 
         Parameters
         ----------
+        track_id_offset : int
+            The starting track id, useful when assigning track ids to a subgraph.
         output_key : str
             The key of the output track id attribute.
         reset : bool
@@ -1030,7 +1033,7 @@ class RustWorkXGraph(BaseGraph):
             A compressed graph (parent -> child) with track ids lineage relationships.
         """
         try:
-            node_ids, track_ids, tracks_graph = _assign_track_ids(self.rx_graph)
+            node_ids, track_ids, tracks_graph = _assign_track_ids(self.rx_graph, track_id_offset)
         except RuntimeError as e:
             raise RuntimeError(
                 "Are you sure this graph is a valid lineage graph?\n"
@@ -1043,7 +1046,10 @@ class RustWorkXGraph(BaseGraph):
         elif reset:
             self.update_node_attrs(node_ids=self.node_ids(), attrs={output_key: -1})
 
-        self.update_node_attrs(
+        # Casting since we don't need node_id mapping for the indexed graph.
+        # XXX better way to enforce this?
+        RustWorkXGraph.update_node_attrs(
+            self,
             node_ids=node_ids,
             attrs={output_key: track_ids},
         )

--- a/src/tracksdata/graph/_rustworkx_graph.py
+++ b/src/tracksdata/graph/_rustworkx_graph.py
@@ -1046,8 +1046,8 @@ class RustWorkXGraph(BaseGraph):
         elif reset:
             self.update_node_attrs(node_ids=self.node_ids(), attrs={output_key: -1})
 
-        # Casting since we don't need node_id mapping for the indexed graph.
-        # XXX better way to enforce this?
+        # node_ids are rustworkx graph ids, therefore we don't need node_id mapping
+        # and we must use RustWorkXGraph for IndexedRXGraph
         RustWorkXGraph.update_node_attrs(
             self,
             node_ids=node_ids,

--- a/src/tracksdata/graph/_test/test_graph_backends.py
+++ b/src/tracksdata/graph/_test/test_graph_backends.py
@@ -1325,6 +1325,10 @@ def test_assign_track_ids(graph_backend: BaseGraph):
         graph_backend.add_edge(nodes[0], nodes[2], {})
 
     tracks_graph = graph_backend.assign_track_ids()
+    track_ids = graph_backend.node_attrs(attr_keys=[DEFAULT_ATTR_KEYS.TRACK_ID])
+    assert len(track_ids) == 3
+    assert len(set(track_ids[DEFAULT_ATTR_KEYS.TRACK_ID])) == 3
+    # assert len
 
     ## Should create 2 tracks: one for each branch
     # assert len(node_ids) == 3

--- a/src/tracksdata/graph/_test/test_graph_backends.py
+++ b/src/tracksdata/graph/_test/test_graph_backends.py
@@ -1310,8 +1310,7 @@ def test_spatial_filter_basic(graph_backend: BaseGraph) -> None:
 
 def test_assign_track_ids(graph_backend: BaseGraph):
     if isinstance(graph_backend, SQLGraph):
-        return
-        # with pytest.raises()
+        pytest.skip("`assign_track_ids` is not available for `SQLGraph`")
     else:
         # Add nodes:
         #     0

--- a/src/tracksdata/graph/_test/test_graph_backends.py
+++ b/src/tracksdata/graph/_test/test_graph_backends.py
@@ -1331,10 +1331,6 @@ def test_assign_track_ids(graph_backend: BaseGraph):
     assert len(set(track_ids[DEFAULT_ATTR_KEYS.TRACK_ID])) == 3
     # assert len
 
-    ## Should create 2 tracks: one for each branch
-    # assert len(node_ids) == 3
-    # assert len(track_ids) == 3
-    # assert len(np.unique(track_ids)) == 3  # Three unique track IDs
     assert isinstance(tracks_graph, rx.PyDiGraph)
     assert tracks_graph.num_nodes() == 3 + 1  # Three tracks (includes null node (0))
 


### PR DESCRIPTION
Solving two issues
- Missing the argument `track_id_offset` from `_assign_track_ids`.
- Incompatible node IDs for `IndexedRXGraph` since `update_node_attrs` assumes pre-mapped IDs and `_assign_track_ids` returns post-mapped IDs.