### PR TITLE
Fix node id map empty graph

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
   "ilpy >= 0.5.1",
   "pyarrow",
   "bidict>=0.23.1",
-  "geff @ git+https://github.com/live-image-tracking-tools/geff.git",
+  "geff @ git+https://github.com/live-image-tracking-tools/geff.git@b751718f81d107e1fdda2df2afb62253039c137b",
 ]
 
 [project.optional-dependencies]

--- a/src/tracksdata/graph/_rustworkx_graph.py
+++ b/src/tracksdata/graph/_rustworkx_graph.py
@@ -1264,7 +1264,7 @@ class IndexedRXGraph(RustWorkXGraph, MappedGraphMixin):
             # Validate for duplicate values before inverting
             # This will raise bidict.ValueDuplicationError if there are duplicates
             inverted_map = bidict.bidict(node_id_map).inverse
-            self._next_external_id = max(node_id_map.keys()) + 1
+            self._next_external_id = max(node_id_map.keys(), default=0) + 1
         else:
             self._next_external_id = 0
 

--- a/src/tracksdata/graph/_test/test_index_graph.py
+++ b/src/tracksdata/graph/_test/test_index_graph.py
@@ -97,6 +97,11 @@ def test_add_node_with_none_index_avoids_collision() -> None:
 
 def test_add_node_none_index_empty_graph() -> None:
     """Test that add_node with index=None works correctly on empty graph."""
+
+    # test with empty graph and empty node_id_map
+    graph = IndexedRXGraph(rx_graph=rx.PyDiGraph(), node_id_map={})
+
+    # test with empty graph and no node_id_map
     graph = IndexedRXGraph()
 
     # First node with None index should get ID 0


### PR DESCRIPTION
This PR fixes the very minor/unique bug that happens when initializing a `IndexedRXGraph` with an empty `rx_graph` and an empty `node_id_map`