### PR TITLE
Copy method

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
   "ilpy >= 0.5.1",
   "pyarrow",
   "bidict>=0.23.1",
-  "geff @ git+https://github.com/live-image-tracking-tools/geff.git",
+  "geff @ git+https://github.com/live-image-tracking-tools/geff.git@b751718f81d107e1fdda2df2afb62253039c137b",
 ]
 
 [project.optional-dependencies]

--- a/src/tracksdata/graph/_base_graph.py
+++ b/src/tracksdata/graph/_base_graph.py
@@ -1265,7 +1265,7 @@ class BaseGraph(abc.ABC):
         """
         Return the edge id between two nodes.
         """
-        
+
     def copy(self, **kwargs) -> "BaseGraph":
         """
         Create a copy of this graph.

--- a/src/tracksdata/graph/_base_graph.py
+++ b/src/tracksdata/graph/_base_graph.py
@@ -1265,3 +1265,27 @@ class BaseGraph(abc.ABC):
         """
         Return the edge id between two nodes.
         """
+        
+    def copy(self, **kwargs) -> "BaseGraph":
+        """
+        Create a copy of this graph.
+
+        Returns
+        -------
+        BaseGraph
+            A new graph instance with the same nodes, edges, and attributes as this graph.
+        **kwargs : Any
+            Additional arguments to pass to the graph constructor.
+
+        Examples
+        --------
+        ```python
+        copied_graph = graph.copy()
+        ```
+
+        See Also
+        --------
+        [from_other][tracksdata.graph.BaseGraph.from_other]:
+            Create a graph from another graph.
+        """
+        return self.__class__.from_other(self, **kwargs)

--- a/src/tracksdata/graph/_graph_view.py
+++ b/src/tracksdata/graph/_graph_view.py
@@ -681,3 +681,48 @@ class GraphView(RustWorkXGraph, MappedGraphMixin):
         Return the edge id between two nodes.
         """
         return self._root.edge_id(source_id, target_id)
+
+    def copy(self, **kwargs) -> "GraphView":
+        """
+        Create a copy of this graph view.
+
+        This method creates a new graph view that is a copy of the current one,
+        preserving all mappings, relationships, and attributes. The copy maintains
+        its relationship with the root graph but has its own independent state.
+
+        Parameters
+        ----------
+        **kwargs : Any
+            Additional arguments to pass to the graph constructor.
+
+        Returns
+        -------
+        GraphView
+            A new graph view instance with the same nodes, edges, attributes,
+            and root graph relationship as this view.
+
+        Examples
+        --------
+        ```python
+        copied_view = graph_view.copy()
+        ```
+        """
+        # Create a copy of the underlying rustworkx graph
+        rx_graph_copy = rx.PyDiGraph(multigraph=self.rx_graph.multigraph)
+        rx_graph_copy.add_nodes_from(self.rx_graph.nodes())
+        rx_graph_copy.add_edges_from(self.rx_graph.weighted_edge_list())
+
+        # Create a new view with the same root and mappings
+        copied_view = GraphView(
+            rx_graph=rx_graph_copy,
+            node_map_to_root=dict(self._local_to_external.items()),
+            root=self._root,
+            sync=self._sync,
+        )
+
+        # The constructor already sets up edge mappings correctly
+        # but we need to copy other attributes
+        copied_view._is_root_rx_graph = self._is_root_rx_graph
+        copied_view._out_of_sync = self._out_of_sync
+
+        return copied_view

--- a/src/tracksdata/graph/_test/test_subgraph.py
+++ b/src/tracksdata/graph/_test/test_subgraph.py
@@ -1112,3 +1112,14 @@ def test_edge_id(graph_backend: BaseGraph, use_subgraph: bool) -> None:
     for attr in edge_attrs.rows(named=True):
         edge_id = graph_with_data.edge_id(attr[DEFAULT_ATTR_KEYS.EDGE_SOURCE], attr[DEFAULT_ATTR_KEYS.EDGE_TARGET])
         assert edge_id == attr[DEFAULT_ATTR_KEYS.EDGE_ID]
+
+@parametrize_subgraph_tests
+def test_copy(graph_backend: BaseGraph, use_subgraph: bool) -> None:
+    """Test copy functionality on both original graphs and subgraphs."""
+    graph_with_data = create_test_graph(graph_backend, use_subgraph)
+
+    copied_graph = graph_with_data.copy()
+    assert copied_graph.num_nodes == graph_with_data.num_nodes
+    assert copied_graph.num_edges == graph_with_data.num_edges
+    assert copied_graph.node_ids() == graph_with_data.node_ids()
+    assert copied_graph.edge_ids() == graph_with_data.edge_ids()

--- a/src/tracksdata/graph/_test/test_subgraph.py
+++ b/src/tracksdata/graph/_test/test_subgraph.py
@@ -1125,6 +1125,7 @@ def test_edge_id(graph_backend: BaseGraph, use_subgraph: bool) -> None:
         edge_id = graph_with_data.edge_id(attr[DEFAULT_ATTR_KEYS.EDGE_SOURCE], attr[DEFAULT_ATTR_KEYS.EDGE_TARGET])
         assert edge_id == attr[DEFAULT_ATTR_KEYS.EDGE_ID]
 
+
 @parametrize_subgraph_tests
 def test_copy(graph_backend: BaseGraph, use_subgraph: bool) -> None:
     """Test copy functionality on both original graphs and subgraphs."""


### PR DESCRIPTION
My attempt in making a `.copy()` function working across all graph backends. 

So far: 
- I added `.copy()` to `_base_graph.py`, this one works for `RXgraph` and `IndexedRXGraph`
- for the copy to work with GraphViews, I added an extra `.copy()` method to `_graph_view.py`, that basically treats it as an rustworkx graph
- I added tests to test the copy functionality for all backends, they pass except for 1: `SQLgraph-original`