### PR TITLE
Removing the "Null" node from `assign_track_ids`.

### DIFF
--- a/src/tracksdata/functional/_napari.py
+++ b/src/tracksdata/functional/_napari.py
@@ -104,7 +104,7 @@ def to_napari_format(
         solution_graph = graph
 
     tracks_graph = solution_graph.assign_track_ids(output_track_id_key)
-    dict_graph = {child: parent for parent, child in tracks_graph.edge_list()}
+    dict_graph = {tracks_graph[child]: tracks_graph[parent] for parent, child in tracks_graph.edge_list()}
 
     spatial_cols = ["z", "y", "x"][-len(shape) + 1 :]
 

--- a/src/tracksdata/functional/_rx.py
+++ b/src/tracksdata/functional/_rx.py
@@ -292,7 +292,7 @@ def _assign_track_ids(
     n_tracks = len(track_ids)
 
     tracks_graph = rx.PyDiGraph(node_count_hint=n_tracks, edge_count_hint=n_tracks)
-    tracks_graph.add_node(0)
+
     node_ids = tracks_graph.add_nodes_from(track_ids)
     track_id_to_rx_node_id = _numba_build_dict(
         np.asarray(track_ids, dtype=np.int64),

--- a/src/tracksdata/functional/_test/test_rx.py
+++ b/src/tracksdata/functional/_test/test_rx.py
@@ -27,7 +27,7 @@ def test_single_path() -> None:
     assert np.array_equal(node_ids, [0, 1, 2])
     assert np.array_equal(track_ids, [1, 1, 1])
     assert isinstance(tracks_graph, rx.PyDiGraph)
-    assert tracks_graph.num_nodes() == 1 + 1  # Single track (includes null node (0))
+    assert tracks_graph.num_nodes() == 1  # Single track
 
 
 def test_symmetric_branching_path() -> None:
@@ -53,7 +53,7 @@ def test_symmetric_branching_path() -> None:
     assert len(track_ids) == 3
     assert len(np.unique(track_ids)) == 3  # Three unique track IDs
     assert isinstance(tracks_graph, rx.PyDiGraph)
-    assert tracks_graph.num_nodes() == 3 + 1  # Three tracks (includes null node (0))
+    assert tracks_graph.num_nodes() == 3  # Three tracks
 
 
 def test_asymmetric_branching_path() -> None:
@@ -83,7 +83,7 @@ def test_asymmetric_branching_path() -> None:
     assert len(track_ids) == 4
     assert len(np.unique(track_ids)) == 3  # Three unique track IDs
     assert isinstance(tracks_graph, rx.PyDiGraph)
-    assert tracks_graph.num_nodes() == 3 + 1  # Three tracks (includes null node (0))
+    assert tracks_graph.num_nodes() == 3  # Three tracks
 
 
 def test_invalid_multiple_parents() -> None:
@@ -139,15 +139,19 @@ def test_complex_valid_branching() -> None:
     np.testing.assert_array_equal(node_ids, [0, 1, 3, 4, 2, 5])
     np.testing.assert_array_equal(track_ids, [1, 2, 2, 2, 3, 4])
 
-    assert set(tracks_graph.successor_indices(1)) == {2, 3}
-    assert set(tracks_graph.successor_indices(3)) == {4}
+    assert set(tracks_graph.successor_indices(tracks_graph.find_node_by_weight(1))) == set(
+        map(tracks_graph.find_node_by_weight, {2, 3})
+    )
+    assert set(tracks_graph.successor_indices(tracks_graph.find_node_by_weight(3))) == set(
+        map(tracks_graph.find_node_by_weight, {4})
+    )
     assert tracks_graph.num_edges() == 3
 
     assert len(node_ids) == 6
     assert len(track_ids) == 6
     assert len(np.unique(track_ids)) == 4  # {0, {1, 3, 4}, 2, 5}
     assert isinstance(tracks_graph, rx.PyDiGraph)
-    assert tracks_graph.num_nodes() == 4 + 1  # Five tracks (includes null node (0))
+    assert tracks_graph.num_nodes() == 4  # Four tracks
 
 
 def test_three_children() -> None:
@@ -169,7 +173,9 @@ def test_three_children() -> None:
     graph.add_edge(nodes[0], nodes[3], None)
 
     _, track_ids, tracks_graph = _assign_track_ids(graph, track_id_offset=1)
-    assert set(tracks_graph.successor_indices(track_ids[0])) == set(track_ids[1:])
+    track_graphs_node_id = tracks_graph.find_node_by_weight(track_ids[0])
+    successor_node_ids = tracks_graph.successor_indices(track_graphs_node_id)
+    assert {tracks_graph[i] for i in successor_node_ids} == set(track_ids[1:])
 
 
 def test_multiple_roots() -> None:
@@ -188,4 +194,4 @@ def test_multiple_roots() -> None:
     assert len(track_ids) == 4
     assert len(np.unique(track_ids)) == 2  # Two unique track IDs
     assert isinstance(tracks_graph, rx.PyDiGraph)
-    assert tracks_graph.num_nodes() == 2 + 1  # Two separate tracks (includes null node (0))
+    assert tracks_graph.num_nodes() == 2  # Two separate tracks

--- a/src/tracksdata/graph/_test/test_graph_backends.py
+++ b/src/tracksdata/graph/_test/test_graph_backends.py
@@ -1328,7 +1328,7 @@ def test_assign_track_ids(graph_backend: BaseGraph):
     assert len(track_ids) == 3
     assert len(set(track_ids[DEFAULT_ATTR_KEYS.TRACK_ID])) == 3
     assert isinstance(tracks_graph, rx.PyDiGraph)
-    assert tracks_graph.num_nodes() == 3 + 1  # Three tracks (includes null node (0))
+    assert tracks_graph.num_nodes() == 3  # Three tracks
 
     tracks_graph = graph_backend.assign_track_ids(track_id_offset=100)
     track_ids = graph_backend.node_attrs(attr_keys=[DEFAULT_ATTR_KEYS.TRACK_ID])
@@ -1336,7 +1336,7 @@ def test_assign_track_ids(graph_backend: BaseGraph):
     assert len(set(track_ids[DEFAULT_ATTR_KEYS.TRACK_ID])) == 3
     assert min(track_ids[DEFAULT_ATTR_KEYS.TRACK_ID]) == 100
     assert isinstance(tracks_graph, rx.PyDiGraph)
-    assert tracks_graph.num_nodes() == 3 + 1  # Three tracks (includes null node (0))
+    assert tracks_graph.num_nodes() == 3  # Three tracks
 
 
 def test_tracklet_graph_basic(graph_backend: BaseGraph) -> None:


### PR DESCRIPTION
This is a follow-up PR for #150, removing the "0" node from the track graph in `assign_track_ids` and updating relevant pieces of the code.