### PR TITLE
Retrieving pickle dtype to avoid sqlgraph mask update error

### DIFF
--- a/src/tracksdata/graph/_sql_graph.py
+++ b/src/tracksdata/graph/_sql_graph.py
@@ -488,6 +488,8 @@ class SQLGraph(BaseGraph):
             pass
 
         if len(metadata.tables) > 0 and not overwrite:
+            for table in metadata.tables.values():
+                self._restore_pickled_column_types(table)
             for table_name, table in metadata.tables.items():
                 cls = type(
                     table_name,
@@ -536,6 +538,11 @@ class SQLGraph(BaseGraph):
         self.Edge = Edge
         self.Overlap = Overlap
         self.Metadata = Metadata
+
+    def _restore_pickled_column_types(self, table: sa.Table) -> None:
+        for column in table.columns:
+            if isinstance(column.type, sa.LargeBinary):
+                column.type = sa.PickleType()
 
     def _polars_schema_override(self, table_class: type[DeclarativeBase]) -> SchemaDict:
         return {


### PR DESCRIPTION
This pull request addresses the handling of pickled column types in SQL-based graph backends, ensuring that columns storing pickled Python objects (such as custom masks) are correctly restored after reloading from disk. The changes also add a test to verify this behavior.

**Persistence and restoration of pickled column types:**

* Added the `_restore_pickled_column_types` method to the `Metadata` class, which scans table columns and restores any `LargeBinary` columns to use `PickleType` upon table loading. This ensures that custom Python objects remain deserializable after database reloads.
* Updated the table loading logic in the `Base` class to invoke `_restore_pickled_column_types` for each table when not overwriting, so column types are restored before ORM class creation.

**Testing improvements:**

* Added the `test_sql_graph_mask_update_survives_reload` test to ensure that a pickled `Mask` object can be updated and retrieved correctly after reloading the SQL database, verifying the persistence fix.