### PR TITLE
Caching `spatial_filter`

### DIFF
--- a/src/tracksdata/graph/_rustworkx_graph.py
+++ b/src/tracksdata/graph/_rustworkx_graph.py
@@ -11,7 +11,8 @@ from tracksdata.attrs import AttrComparison, split_attr_comps
 from tracksdata.constants import DEFAULT_ATTR_KEYS
 from tracksdata.graph._base_graph import BaseGraph
 from tracksdata.graph._mapped_graph_mixin import MappedGraphMixin
-from tracksdata.graph.filters._base_filter import BaseFilter, cache_method
+from tracksdata.graph.filters._base_filter import BaseFilter
+from tracksdata.utils._cache import cache_method
 from tracksdata.utils._dataframe import unpack_array_attrs
 from tracksdata.utils._logging import LOG
 from tracksdata.utils._signal import is_signal_on

--- a/src/tracksdata/graph/_sql_graph.py
+++ b/src/tracksdata/graph/_sql_graph.py
@@ -16,7 +16,8 @@ from sqlalchemy.sql.type_api import TypeEngine
 from tracksdata.attrs import AttrComparison, split_attr_comps
 from tracksdata.constants import DEFAULT_ATTR_KEYS
 from tracksdata.graph._base_graph import BaseGraph
-from tracksdata.graph.filters._base_filter import BaseFilter, cache_method
+from tracksdata.graph.filters._base_filter import BaseFilter
+from tracksdata.utils._cache import cache_method
 from tracksdata.utils._dataframe import unpack_array_attrs, unpickle_bytes_columns
 from tracksdata.utils._logging import LOG
 from tracksdata.utils._signal import is_signal_on

--- a/src/tracksdata/graph/filters/_base_filter.py
+++ b/src/tracksdata/graph/filters/_base_filter.py
@@ -1,11 +1,7 @@
 import abc
-import functools
-from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any
 
 import polars as pl
-
-from tracksdata.utils._logging import LOG
 
 if TYPE_CHECKING:
     from tracksdata.graph._graph_view import GraphView
@@ -57,57 +53,3 @@ class BaseFilter(abc.ABC):
         """
         Get a subgraph of the graph resulting from the filter.
         """
-
-
-def _make_hashable(obj: Any) -> Any:
-    if isinstance(obj, tuple | list):
-        return tuple(_make_hashable(o) for o in obj)
-    elif isinstance(obj, dict):
-        return tuple(sorted((_make_hashable(k), _make_hashable(v)) for k, v in obj.items()))
-    elif isinstance(obj, set):
-        return frozenset(_make_hashable(o) for o in obj)
-    elif hasattr(obj, "__dict__"):
-        return _make_hashable(vars(obj))  # for custom objects
-    elif hasattr(obj, "__hash__") and obj.__hash__:
-        return obj
-    else:
-        return repr(obj)  # fallback for anything else
-
-
-F = TypeVar("F", bound=Callable[..., Any])
-
-
-def cache_method(func: F) -> F:
-    """
-    Cache the result of a method.
-
-    Parameters
-    ----------
-    func : Callable[..., Any]
-        The method to cache.
-
-    Returns
-    -------
-    Callable[..., Any]
-        The wrapped method.
-    """
-
-    @functools.wraps(func)
-    def _wrapper(self: BaseFilter, *args: Any, **kwargs: Any) -> Any:
-        try:
-            key = (
-                func.__name__,
-                _make_hashable(args),
-                _make_hashable(kwargs),
-            )
-        except Exception as e:
-            LOG.warning(f"_{func.__name__} failed to hash {args} and {kwargs}:\n{e}")
-            return func(self, *args, **kwargs)
-
-        if key in self._cache:
-            return self._cache[key]
-        result = func(self, *args, **kwargs)
-        self._cache[key] = result
-        return result
-
-    return _wrapper

--- a/src/tracksdata/graph/filters/_indexed_filter.py
+++ b/src/tracksdata/graph/filters/_indexed_filter.py
@@ -10,7 +10,7 @@ from tracksdata.graph._rustworkx_graph import (
     RXFilter,
     _create_filter_func,
 )
-from tracksdata.graph.filters._base_filter import cache_method
+from tracksdata.utils._cache import cache_method
 
 if TYPE_CHECKING:
     from tracksdata.graph._graph_view import GraphView

--- a/src/tracksdata/graph/filters/_test/test_spatial_filter.py
+++ b/src/tracksdata/graph/filters/_test/test_spatial_filter.py
@@ -82,7 +82,9 @@ def test_spatial_filter_caches_filters(sample_graph: RustWorkXGraph, monkeypatch
     assert first is not default_first
     assert created_attr_keys == [["y", "x"], None]
 
-    third = sample_graph.spatial_filter(attr_keys=["y", "x"], clear_cache=True)
+    sample_graph.clear_cache()
+    third = sample_graph.spatial_filter(attr_keys=["y", "x"])
+
     assert third is not first
     assert created_attr_keys == [["y", "x"], None, ["y", "x"]]
 
@@ -107,7 +109,8 @@ def test_bbox_spatial_filter_caches_filters(sample_graph: RustWorkXGraph, monkey
     assert first is not default_first
     assert created_attr_keys == [("frame", "bbox2"), (DEFAULT_ATTR_KEYS.T, DEFAULT_ATTR_KEYS.BBOX)]
 
-    third = sample_graph.bbox_spatial_filter(frame_attr_key="frame", bbox_attr_key="bbox2", clear_cache=True)
+    sample_graph.clear_cache()
+    third = sample_graph.bbox_spatial_filter(frame_attr_key="frame", bbox_attr_key="bbox2")
     assert third is not first
     assert created_attr_keys == [("frame", "bbox2"), (DEFAULT_ATTR_KEYS.T, DEFAULT_ATTR_KEYS.BBOX), ("frame", "bbox2")]
 

--- a/src/tracksdata/utils/_cache.py
+++ b/src/tracksdata/utils/_cache.py
@@ -1,0 +1,66 @@
+import functools
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+from tracksdata.utils._logging import LOG
+
+
+def _make_hashable(obj: Any) -> Any:
+    if isinstance(obj, tuple | list):
+        return tuple(_make_hashable(o) for o in obj)
+    elif isinstance(obj, dict):
+        return tuple(sorted((_make_hashable(k), _make_hashable(v)) for k, v in obj.items()))
+    elif isinstance(obj, set):
+        return frozenset(_make_hashable(o) for o in obj)
+    elif hasattr(obj, "__dict__"):
+        return _make_hashable(vars(obj))  # for custom objects
+    elif hasattr(obj, "__hash__") and obj.__hash__:
+        return obj
+    else:
+        return repr(obj)  # fallback for anything else
+
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def cache_method(func: F) -> F:
+    """
+    Cache the result of a method.
+
+    Parameters
+    ----------
+    func : Callable[..., Any]
+        The method to cache.
+
+    Returns
+    -------
+    Callable[..., Any]
+        The wrapped method.
+    """
+
+    @functools.wraps(func)
+    def _wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
+        if not hasattr(self, "_cache"):
+            LOG.warning(
+                f"{self.__class__.__name__} has no `_cache` attribute.\n"
+                "Adding for this class instance. The code should be refactored to add `_cache` to the class itself."
+            )
+            self._cache = {}
+
+        try:
+            key = (
+                func.__name__,
+                _make_hashable(args),
+                _make_hashable(kwargs),
+            )
+        except Exception as e:
+            LOG.warning(f"_{func.__name__} failed to hash {args} and {kwargs}:\n{e}")
+            return func(self, *args, **kwargs)
+
+        if key in self._cache:
+            return self._cache[key]
+        result = func(self, *args, **kwargs)
+        self._cache[key] = result
+        return result
+
+    return _wrapper


### PR DESCRIPTION
Caching `spatial_filter` reduces time to build the `rtree`. I believe it is safe to share the `spatial_filter` for the same argument and therefore cache it in the `BaseGraph` object.