### PR TITLE
Allows `node_ids=None` for `successors` and `predecessors`

### DIFF
--- a/src/tracksdata/graph/_base_graph.py
+++ b/src/tracksdata/graph/_base_graph.py
@@ -397,7 +397,7 @@ class BaseGraph(abc.ABC):
     @overload
     def successors(
         self,
-        node_ids: list[int],
+        node_ids: list[int] | None,
         attr_keys: Sequence[str] | str | None = ...,
         *,
         return_attrs: Literal[True],
@@ -415,7 +415,7 @@ class BaseGraph(abc.ABC):
     @overload
     def successors(
         self,
-        node_ids: list[int],
+        node_ids: list[int] | None,
         attr_keys: Sequence[str] | str | None = ...,
         *,
         return_attrs: Literal[False] = False,
@@ -424,7 +424,7 @@ class BaseGraph(abc.ABC):
     @abc.abstractmethod
     def successors(
         self,
-        node_ids: list[int] | int,
+        node_ids: list[int] | int | None,
         attr_keys: Sequence[str] | str | None = None,
         *,
         return_attrs: bool = False,
@@ -434,8 +434,9 @@ class BaseGraph(abc.ABC):
 
         Parameters
         ----------
-        node_ids : list[int] | int
+        node_ids : list[int] | int | None
             The IDs of the nodes to get the sucessors for.
+            If None, all nodes are used.
         attr_keys : Sequence[str] | str | None
             The attribute keys to retrieve when ``return_attrs`` is True.
             If None, all attributes are included.
@@ -464,7 +465,7 @@ class BaseGraph(abc.ABC):
     @overload
     def predecessors(
         self,
-        node_ids: list[int],
+        node_ids: list[int] | None,
         attr_keys: Sequence[str] | str | None = ...,
         *,
         return_attrs: Literal[True],
@@ -482,7 +483,7 @@ class BaseGraph(abc.ABC):
     @overload
     def predecessors(
         self,
-        node_ids: list[int],
+        node_ids: list[int] | None,
         attr_keys: Sequence[str] | str | None = ...,
         *,
         return_attrs: Literal[False] = False,
@@ -491,7 +492,7 @@ class BaseGraph(abc.ABC):
     @abc.abstractmethod
     def predecessors(
         self,
-        node_ids: list[int] | int,
+        node_ids: list[int] | int | None,
         attr_keys: Sequence[str] | str | None = None,
         *,
         return_attrs: bool = False,
@@ -501,8 +502,8 @@ class BaseGraph(abc.ABC):
 
         Parameters
         ----------
-        node_ids : list[int] | int
-            The IDs of the nodes to get the predecessors for.
+        node_ids : list[int] | int | None
+            The IDs of the nodes to get the predecessors for. If None, all nodes are used.
         attr_keys : Sequence[str] | str | None
             The attribute keys to retrieve when ``return_attrs`` is True.
             If None, all attributes are included.

--- a/src/tracksdata/graph/_graph_view.py
+++ b/src/tracksdata/graph/_graph_view.py
@@ -419,13 +419,15 @@ class GraphView(RustWorkXGraph, MappedGraphMixin):
     def _get_neighbors(
         self,
         neighbors_func: Callable[[rx.PyDiGraph, int], rx.NodeIndices],
-        node_ids: list[int] | int,
+        node_ids: list[int] | int | None,
         attr_keys: Sequence[str] | str | None = None,
         *,
         return_attrs: bool = False,
     ) -> dict[int, pl.DataFrame] | pl.DataFrame | dict[int, list[int]] | list[int]:
         single_node = False
-        if isinstance(node_ids, int):
+        if node_ids is None:
+            node_ids = self.node_ids()
+        elif isinstance(node_ids, int):
             node_ids = [node_ids]
             single_node = True
 
@@ -456,7 +458,7 @@ class GraphView(RustWorkXGraph, MappedGraphMixin):
 
     def successors(
         self,
-        node_ids: list[int] | int,
+        node_ids: list[int] | int | None,
         attr_keys: Sequence[str] | str | None = None,
         *,
         return_attrs: bool = False,
@@ -467,7 +469,7 @@ class GraphView(RustWorkXGraph, MappedGraphMixin):
 
     def predecessors(
         self,
-        node_ids: list[int] | int,
+        node_ids: list[int] | int | None,
         attr_keys: Sequence[str] | str | None = None,
         *,
         return_attrs: bool = False,

--- a/src/tracksdata/graph/_rustworkx_graph.py
+++ b/src/tracksdata/graph/_rustworkx_graph.py
@@ -656,7 +656,7 @@ class RustWorkXGraph(BaseGraph):
     def _get_neighbors(
         self,
         neighbors_func: Callable[[rx.PyDiGraph, int], rx.NodeIndices],
-        node_ids: list[int] | int,
+        node_ids: list[int] | int | None,
         attr_keys: Sequence[str] | str | None = None,
         *,
         return_attrs: bool = False,
@@ -666,11 +666,13 @@ class RustWorkXGraph(BaseGraph):
         See more information below.
         """
         single_node = False
-        if isinstance(node_ids, int):
+        rx_graph = self.rx_graph
+        if node_ids is None:
+            node_ids = list(rx_graph.node_indices())
+        elif isinstance(node_ids, int):
             node_ids = [node_ids]
             single_node = True
 
-        rx_graph = self.rx_graph
         if not return_attrs and attr_keys is not None:
             LOG.warning("attr_keys is ignored when return_attrs is False.")
 
@@ -717,7 +719,7 @@ class RustWorkXGraph(BaseGraph):
 
     def successors(
         self,
-        node_ids: list[int] | int,
+        node_ids: list[int] | int | None,
         attr_keys: Sequence[str] | str | None = None,
         *,
         return_attrs: bool = False,
@@ -727,8 +729,9 @@ class RustWorkXGraph(BaseGraph):
 
         Parameters
         ----------
-        node_ids : list[int] | int
+        node_ids : list[int] | int | None
             The IDs of the nodes to get the sucessors for.
+            If None, all nodes are used.
         attr_keys : Sequence[str] | str | None
             The attribute keys to retrieve when ``return_attrs`` is True.
             If None, all attributes are included.
@@ -753,7 +756,7 @@ class RustWorkXGraph(BaseGraph):
 
     def predecessors(
         self,
-        node_ids: list[int] | int,
+        node_ids: list[int] | int | None,
         attr_keys: Sequence[str] | str | None = None,
         *,
         return_attrs: bool = False,
@@ -763,8 +766,9 @@ class RustWorkXGraph(BaseGraph):
 
         Parameters
         ----------
-        node_ids : list[int] | int
+        node_ids : list[int] | int | None
             The IDs of the nodes to get the predecessors for.
+            If None, all nodes are used.
         attr_keys : Sequence[str] | str | None
             The attribute keys to retrieve when ``return_attrs`` is True.
             If None, all attributes are included.

--- a/src/tracksdata/graph/_test/test_graph_backends.py
+++ b/src/tracksdata/graph/_test/test_graph_backends.py
@@ -675,11 +675,27 @@ def test_sucessors_and_degree(graph_backend: BaseGraph) -> None:
     assert successors_dict[node1] == [node2]
     assert successors_dict[node2] == []
 
+    successors_all = graph_backend.successors(None)
+    assert isinstance(successors_all, dict)
+    assert set(successors_all.keys()) == {node0, node1, node2, node3}
+    assert sorted(successors_all[node0]) == sorted([node1, node3])
+    assert successors_all[node1] == [node2]
+    assert successors_all[node2] == []
+    assert successors_all[node3] == []
+
     successors_dict_df = graph_backend.successors([node0, node1, node2], return_attrs=True)
     assert isinstance(successors_dict_df[node0], pl.DataFrame)
     assert set(successors_dict_df[node0][DEFAULT_ATTR_KEYS.NODE_ID].to_list()) == {node1, node3}
     assert set(successors_dict_df[node1][DEFAULT_ATTR_KEYS.NODE_ID].to_list()) == {node2}
     assert len(successors_dict_df[node2]) == 0
+
+    successors_all_df = graph_backend.successors(None, return_attrs=True)
+    assert isinstance(successors_all_df, dict)
+    assert set(successors_all_df.keys()) == {node0, node1, node2, node3}
+    assert set(successors_all_df[node0][DEFAULT_ATTR_KEYS.NODE_ID].to_list()) == {node1, node3}
+    assert set(successors_all_df[node1][DEFAULT_ATTR_KEYS.NODE_ID].to_list()) == {node2}
+    assert successors_all_df[node2].is_empty()
+    assert successors_all_df[node3].is_empty()
 
     # testing query all
     assert graph_backend.out_degree() == [2, 1, 0, 0]
@@ -751,12 +767,28 @@ def test_predecessors_and_degree(graph_backend: BaseGraph) -> None:
     assert predecessors_dict[node2] == [node1]
     assert predecessors_dict[node3] == [node0]
 
+    predecessors_all = graph_backend.predecessors(None)
+    assert isinstance(predecessors_all, dict)
+    assert set(predecessors_all.keys()) == {node0, node1, node2, node3}
+    assert predecessors_all[node0] == []
+    assert predecessors_all[node1] == [node0]
+    assert predecessors_all[node2] == [node1]
+    assert predecessors_all[node3] == [node0]
+
     predecessors_dict_df = graph_backend.predecessors([node0, node1, node2, node3], return_attrs=True)
     assert isinstance(predecessors_dict_df[node1], pl.DataFrame)
     assert predecessors_dict_df[node0].is_empty()
     assert set(predecessors_dict_df[node1][DEFAULT_ATTR_KEYS.NODE_ID].to_list()) == {node0}
     assert set(predecessors_dict_df[node2][DEFAULT_ATTR_KEYS.NODE_ID].to_list()) == {node1}
     assert set(predecessors_dict_df[node3][DEFAULT_ATTR_KEYS.NODE_ID].to_list()) == {node0}
+
+    predecessors_all_df = graph_backend.predecessors(None, return_attrs=True)
+    assert isinstance(predecessors_all_df, dict)
+    assert set(predecessors_all_df.keys()) == {node0, node1, node2, node3}
+    assert predecessors_all_df[node0].is_empty()
+    assert set(predecessors_all_df[node1][DEFAULT_ATTR_KEYS.NODE_ID].to_list()) == {node0}
+    assert set(predecessors_all_df[node2][DEFAULT_ATTR_KEYS.NODE_ID].to_list()) == {node1}
+    assert set(predecessors_all_df[node3][DEFAULT_ATTR_KEYS.NODE_ID].to_list()) == {node0}
     assert graph_backend.in_degree() == [0, 1, 1, 1]
     # testing different ordering
     assert graph_backend.in_degree([node0, node1, node2, node3]) == [0, 1, 1, 1]


### PR DESCRIPTION
This pull request enhances the graph API by allowing the `successors` and `predecessors` methods to accept `None` as the `node_ids` argument, which will query all nodes in the graph. The implementation is updated across all graph backends, and comprehensive tests are added to verify the new behavior.

Closes #206.