### PR TITLE
added spacing parameter to regionprops

### DIFF
--- a/src/tracksdata/nodes/_mask.py
+++ b/src/tracksdata/nodes/_mask.py
@@ -370,18 +370,24 @@ class Mask:
         if image_shape is not None:
             self._crop_overhang(image_shape)
 
-    def regionprops(self) -> "RegionProperties":
+    def regionprops(self, spacing: tuple[float, ...] | None = None) -> "RegionProperties":
         """
         Compute scikit-image regionprops for this mask.
 
         The computation is aware of the mask bounding box, so coordinate-based
         properties (e.g. centroid, coords) are returned in absolute
         image coordinates.
+
+        Parameters
+        ----------
+        spacing : tuple[float, ...] | None
+            The spacing of the image in each dimension (scale).
         """
         props = regionprops(
             self._mask.astype(np.uint16),
             cache=True,
             offset=tuple(self._bbox[: self._mask.ndim]),
+            spacing=spacing,
         )
 
         if len(props) != 1:

--- a/src/tracksdata/nodes/_test/test_mask.py
+++ b/src/tracksdata/nodes/_test/test_mask.py
@@ -14,6 +14,18 @@ def test_mask_init() -> None:
     assert np.array_equal(mask._bbox, bbox)
 
 
+def test_mask_regionprops_spacing_aware() -> None:
+    """Regionprops should account for spacing when provided."""
+    mask_array = np.array([[False, True], [True, False]], dtype=bool)
+    bbox = np.array([0, 0, 2, 2])
+    spacing = np.array([2.0, 3.0])  # y-spacing=2.0, x-spacing=3.0
+
+    props = Mask(mask_array, bbox).regionprops(spacing=spacing)
+
+    assert props.area == 12  # area (2) should be scaled by spacing (2*3=6)
+    np.testing.assert_allclose(props.centroid, np.array([1.0, 1.5]))
+
+
 def test_mask_regionprops_bbox_aware() -> None:
     """Regionprops should return absolute coordinates using the bbox offset."""
     mask_array = np.array([[False, True], [True, False]], dtype=bool)


### PR DESCRIPTION
In order to handle a different `scale` than `(1,1,1)`, I added a spacing parameter to the `regionprops` method of `Mask`