### PR TITLE
change single node|edge api

### DIFF
--- a/src/tracksdata/graph/_base_graph.py
+++ b/src/tracksdata/graph/_base_graph.py
@@ -2180,7 +2180,7 @@ class NodeInterface:
         return self._graph.filter(node_ids=[self._node_id]).node_attrs(attr_keys=[key])[key].item()
 
     def __setitem__(self, key: str, value: Any) -> None:
-        return self._graph.update_node_attrs(attrs={key: value}, node_ids=[self._node_id])
+        return self._graph.update_node_attrs(attrs={key: [value]}, node_ids=[self._node_id])
 
     def __str__(self) -> str:
         node_attr = self._graph.filter(node_ids=[self._node_id]).node_attrs()
@@ -2254,7 +2254,7 @@ class EdgeInterface:
         value : Any
             The value to set.
         """
-        return self._graph.update_edge_attrs(attrs={key: value}, edge_ids=[self._edge_id])
+        return self._graph.update_edge_attrs(attrs={key: [value]}, edge_ids=[self._edge_id])
 
     def __str__(self) -> str:
         df = self._graph.edge_attrs()

--- a/src/tracksdata/graph/_test/test_graph_backends.py
+++ b/src/tracksdata/graph/_test/test_graph_backends.py
@@ -2218,23 +2218,36 @@ def test_nodes_interface(graph_backend: BaseGraph) -> None:
     assert graph_backend.nodes[node2].to_dict() == {"t": 1, "x": 0, "y": 5}
     assert graph_backend.nodes[node3].to_dict() == {"t": 2, "x": -1, "y": -1}
 
+    # non-scalar value: setting an array attribute via the single-node interface
+    graph_backend.add_node_attr_key("pos", pl.Array(pl.Float64, 2), default_value=np.array([0.0, 0.0]))
+    graph_backend.nodes[node1]["pos"] = np.array([1.5, 2.5])
+    graph_backend.nodes[node2]["pos"] = np.array([3.0, 4.0])
+    assert list(graph_backend.nodes[node1]["pos"]) == [1.5, 2.5]
+    assert list(graph_backend.nodes[node2]["pos"]) == [3.0, 4.0]
+    assert list(graph_backend.nodes[node3]["pos"]) == [0.0, 0.0]
+
 
 def test_edges_interface(graph_backend: BaseGraph) -> None:
     """Test edge attribute access using graph.edges[edge_id]['attr'] syntax."""
     graph_backend.add_node_attr_key("x", dtype=pl.Int64, default_value=-1)
     graph_backend.add_edge_attr_key("weight", dtype=pl.Float64, default_value=0.0)
     graph_backend.add_edge_attr_key("score", dtype=pl.Float64, default_value=-1.0)
+    graph_backend.add_edge_attr_key("vector", pl.Array(pl.Float64, 2), default_value=np.array([0.0, 0.0]))
 
     # Create nodes and edges
     node1 = graph_backend.add_node({"t": 0, "x": 1})
     node2 = graph_backend.add_node({"t": 1, "x": 2})
     node3 = graph_backend.add_node({"t": 2, "x": 3})
 
-    edge1 = graph_backend.add_edge(node1, node2, {"weight": 0.5, "score": -1.0})
-    graph_backend.add_edge(node2, node3, {"weight": 0.8, "score": -1.0})
+    edge1 = graph_backend.add_edge(node1, node2, {"weight": 0.5, "score": -1.0, "vector": np.array([0.0, 0.0])})
+    graph_backend.add_edge(node2, node3, {"weight": 0.8, "score": -1.0, "vector": np.array([0.0, 0.0])})
 
     # Test getting edge attributes
     assert graph_backend.edges[edge1]["weight"] == 0.5
+
+    # non-scalar value: setting an array attribute via the single-edge interface
+    graph_backend.edges[edge1]["vector"] = np.array([1.0, 2.0])
+    assert list(graph_backend.edges[edge1]["vector"]) == [1.0, 2.0]
 
 
 def test_custom_indices(graph_backend: BaseGraph) -> None:


### PR DESCRIPTION
`NodeInterface.__setitem__` and `EdgeInterface.__setitem__` pass the value directly to the columnar bulk API (`update_node_attrs` / `update_edge_attrs`), which expects each attribute value to be a sequence of per-element entries — one per node/edge ID. Since the single-node/edge interface always targets exactly one ID, any non-scalar value (e.g. a position array `[x, y]`) was misread as a sequence of multiple values, causing a length-mismatch `ValueError`. The fix wraps the value in a list (`[value]`) at the interface layer so the bulk API receives the correct shape, making `graph.nodes[node][attr] = value` work naturally for scalars, lists, and arrays alike, where we previously needed: `graph.nodes[node][attr] = [value]` 
