### PR TITLE
Specialize SQLGraph.from_other for SQLite-to-SQLite (closes #285)

### DIFF
--- a/src/tracksdata/graph/_sql_graph.py
+++ b/src/tracksdata/graph/_sql_graph.py
@@ -1106,9 +1106,12 @@ class SQLGraph(BaseGraph):
         """
         Get the overlaps between the nodes in `node_ids`.
 
-        When ``node_ids`` is provided, the query is split into chunks to keep
-        the number of bound parameters below the backend's limit (notably
-        SQLite's ``SQLITE_MAX_VARIABLE_NUMBER``).
+        When ``node_ids`` is provided, the query is split via
+        :meth:`_chunked_sa_read` to keep the number of bound parameters below
+        the backend's limit (notably SQLite's ``SQLITE_MAX_VARIABLE_NUMBER``).
+        Only the source side is constrained per-chunk; the target side is
+        filtered in Polars afterwards to avoid a quadratic blow-up of bound
+        parameters.
         """
         if hasattr(node_ids, "tolist"):
             node_ids = node_ids.tolist()
@@ -1122,27 +1125,15 @@ class SQLGraph(BaseGraph):
             if len(node_ids) == 0:
                 return []
 
-            # Split the IN(...) clause into chunks. Each chunk uses 2 * chunk_size
-            # bound parameters (one IN clause per source/target column), so we halve
-            # the chunk size to stay below the backend's limit.
-            chunk_size = max(1, self._sql_chunk_size() // 2)
-            node_id_set = set(node_ids)
-            results: list[list[int]] = []
-            seen: set[tuple[int, int]] = set()
-            for i in range(0, len(node_ids), chunk_size):
-                chunk = node_ids[i : i + chunk_size]
-                # Constrain the source side via the chunk and filter the target side
-                # in Python to avoid an O(N^2) blow-up of bound parameters.
-                query = base_query.filter(self.Overlap.source_id.in_(chunk))
-                for source_id, target_id in query.all():
-                    if target_id not in node_id_set:
-                        continue
-                    key = (source_id, target_id)
-                    if key in seen:
-                        continue
-                    seen.add(key)
-                    results.append([source_id, target_id])
-            return results
+            df = self._chunked_sa_read(
+                session,
+                lambda chunk: base_query.filter(self.Overlap.source_id.in_(chunk)),
+                node_ids,
+                self.Overlap,
+            )
+
+        df = df.filter(pl.col("target_id").is_in(node_ids))
+        return [[source_id, target_id] for source_id, target_id in df.iter_rows()]
 
     def has_overlaps(self) -> bool:
         """

--- a/src/tracksdata/graph/_sql_graph.py
+++ b/src/tracksdata/graph/_sql_graph.py
@@ -1,6 +1,8 @@
 import binascii
+import re
 from collections.abc import Callable, Sequence
 from enum import Enum
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar
 
 import cloudpickle
@@ -2120,6 +2122,12 @@ class SQLGraph(BaseGraph):
             and dst_database not in ("", ":memory:")
             and source_root._url.database not in (None, "", ":memory:")
             and source_root._url.database != dst_database
+            # The dump replays the source's CREATE statements against the
+            # destination, so the destination file must start empty.
+            and (not Path(dst_database).exists() or Path(dst_database).stat().st_size == 0)
+            # ``overwrite=True`` would have the dst constructor drop tables
+            # we just populated; let the generic path handle it.
+            and not kwargs.get("overwrite", False)
         )
 
         if sqlite_dump_eligible:
@@ -2132,6 +2140,14 @@ class SQLGraph(BaseGraph):
 
         return super().from_other(other, **kwargs)
 
+    # Match the leading ``CREATE [UNIQUE] {TABLE|INDEX} [IF NOT EXISTS]``
+    # of a SQLite DDL statement so we can splice in an attached-database
+    # qualifier (``_td_dst.``) before the object name.
+    _SQLITE_DDL_QUALIFIER = re.compile(
+        r"^(\s*CREATE\s+(?:UNIQUE\s+)?(?:TABLE|INDEX)\s+(?:IF\s+NOT\s+EXISTS\s+)?)",
+        re.IGNORECASE,
+    )
+
     @classmethod
     def _sqlite_table_dump(
         cls: type["SQLGraph"],
@@ -2142,62 +2158,55 @@ class SQLGraph(BaseGraph):
         kwargs: dict[str, Any],
     ) -> "SQLGraph":
         """
-        Fast SQLite-to-SQLite copy.
+        Fast SQLite-to-SQLite copy via ``ATTACH DATABASE`` + raw DDL/DML.
 
-        Steps:
+        Rather than instantiate the destination upfront and ALTER it into
+        shape, this dumps the source's schema and rows straight into the
+        destination file at the SQL level and then opens the destination
+        :class:`SQLGraph` from the populated file. The constructor's normal
+        reflection path then rebuilds the in-memory state.
 
-        1. Open the destination :class:`SQLGraph` so it materializes its
-           schema (and metadata) on disk.
-        2. Mirror any extra columns/metadata from the source.
-        3. Dispose the destination engine to release the file handle.
-        4. From the source connection, ``ATTACH`` the destination database
-           and stream rows via ``INSERT INTO _td_dst.\"X\" SELECT ... FROM
-           main.\"X\"``. When a node-id subset is given, the IDs are inserted
-           into a temporary table in chunks and used as a join filter, which
-           sidesteps SQLite's bound-parameter limit.
-        5. Re-open the destination engine and refresh derived state.
+        For filtered copies (``source_node_ids`` not ``None``) the selection
+        is materialized in a temp table so the row filter joins instead of
+        using an oversized ``IN (...)`` clause that would hit SQLite's
+        bound-parameter limit.
         """
-        dst = cls(**kwargs)
+        dst_database: str = kwargs["database"]
+        dst_path = Path(dst_database)
 
-        # Mirror schema extensions onto the destination.
-        for key, schema in other._node_attr_schemas().items():
-            if key not in dst._node_attr_schemas():
-                dst.add_node_attr_key(key, schema.dtype, schema.default_value)
-        for key, schema in other._edge_attr_schemas().items():
-            if key not in dst._edge_attr_schemas():
-                dst.add_edge_attr_key(key, schema.dtype, schema.default_value)
+        # The dump replays the source's CREATE statements against the
+        # destination, so the destination must start empty. The eligibility
+        # check in :meth:`from_other` already gates on this for the
+        # well-known cases; fall back defensively for anything else.
+        if dst_path.exists() and dst_path.stat().st_size > 0:
+            return super().from_other(other, **kwargs)
 
-        # Copy metadata before handing off to raw SQL (these go through dst._engine).
-        dst.metadata.update(other.metadata)
-        dst._private_metadata.update(other._private_metadata_for_copy())
-
-        dst_database = dst._url.database
-        dst._engine.dispose()
-
-        node_cols = list(source_root.Node.__table__.columns.keys())
-        edge_cols_no_id = [c for c in source_root.Edge.__table__.columns.keys() if c != DEFAULT_ATTR_KEYS.EDGE_ID]
-        node_cols_sql = ", ".join(f'"{c}"' for c in node_cols)
-        edge_cols_sql = ", ".join(f'"{c}"' for c in edge_cols_no_id)
-
-        chunk_size = max(1, source_root._sql_chunk_size())
-        # ATTACH does not accept bound parameters in every SQLite build; escape
-        # the path safely via single-quote doubling.
+        # ATTACH does not accept bound parameters in every SQLite build, so
+        # escape the path safely via single-quote doubling.
         attach_path = dst_database.replace("'", "''")
 
         with source_root._engine.connect() as conn:
             conn.exec_driver_sql(f"ATTACH DATABASE '{attach_path}' AS _td_dst")
             try:
+                # 1. Replicate the source schema by replaying its DDL against
+                # the attached destination. ``sqlite_master.sql`` is NULL for
+                # auto-generated objects (e.g. PK indexes), which we skip;
+                # tables are created before indexes.
+                ddl_rows = conn.exec_driver_sql(
+                    "SELECT type, sql FROM main.sqlite_master "
+                    "WHERE sql IS NOT NULL AND type IN ('table', 'index') "
+                    "ORDER BY CASE type WHEN 'table' THEN 0 ELSE 1 END"
+                ).fetchall()
+                for _type, ddl in ddl_rows:
+                    qualified = cls._SQLITE_DDL_QUALIFIER.sub(r"\g<1>_td_dst.", ddl, count=1)
+                    conn.exec_driver_sql(qualified)
+
+                # 2. Copy rows. The Metadata table is included verbatim — its
+                # SQL-private schema entries describe the columns we just
+                # cloned and so are valid for the destination as-is.
                 if source_node_ids is None:
-                    conn.exec_driver_sql(
-                        f'INSERT INTO _td_dst."Node" ({node_cols_sql}) SELECT {node_cols_sql} FROM main."Node"'
-                    )
-                    conn.exec_driver_sql(
-                        f'INSERT INTO _td_dst."Edge" ({edge_cols_sql}) SELECT {edge_cols_sql} FROM main."Edge"'
-                    )
-                    conn.exec_driver_sql(
-                        'INSERT INTO _td_dst."Overlap" (source_id, target_id) '
-                        'SELECT source_id, target_id FROM main."Overlap"'
-                    )
+                    for table_name in ("Node", "Edge", "Overlap", "Metadata"):
+                        conn.exec_driver_sql(f'INSERT INTO _td_dst."{table_name}" SELECT * FROM main."{table_name}"')
                 else:
                     node_ids = list(source_node_ids)
                     if hasattr(node_ids, "tolist"):
@@ -2206,6 +2215,7 @@ class SQLGraph(BaseGraph):
                     # filter joins instead of using an oversized IN(...) clause.
                     conn.exec_driver_sql("CREATE TEMP TABLE _td_selected (node_id INTEGER PRIMARY KEY)")
                     insert_stmt = sa.text("INSERT INTO _td_selected (node_id) VALUES (:node_id)")
+                    chunk_size = max(1, source_root._sql_chunk_size())
                     for i in range(0, len(node_ids), chunk_size):
                         batch = node_ids[i : i + chunk_size]
                         conn.execute(
@@ -2214,36 +2224,30 @@ class SQLGraph(BaseGraph):
                         )
 
                     conn.exec_driver_sql(
-                        f'INSERT INTO _td_dst."Node" ({node_cols_sql}) '
-                        f'SELECT {node_cols_sql} FROM main."Node" '
-                        f"WHERE node_id IN (SELECT node_id FROM _td_selected)"
+                        'INSERT INTO _td_dst."Node" SELECT * FROM main."Node" '
+                        "WHERE node_id IN (SELECT node_id FROM _td_selected)"
                     )
                     conn.exec_driver_sql(
-                        f'INSERT INTO _td_dst."Edge" ({edge_cols_sql}) '
-                        f'SELECT {edge_cols_sql} FROM main."Edge" '
-                        f"WHERE source_id IN (SELECT node_id FROM _td_selected) "
-                        f"AND target_id IN (SELECT node_id FROM _td_selected)"
-                    )
-                    conn.exec_driver_sql(
-                        'INSERT INTO _td_dst."Overlap" (source_id, target_id) '
-                        'SELECT source_id, target_id FROM main."Overlap" '
+                        'INSERT INTO _td_dst."Edge" SELECT * FROM main."Edge" '
                         "WHERE source_id IN (SELECT node_id FROM _td_selected) "
                         "AND target_id IN (SELECT node_id FROM _td_selected)"
                     )
+                    conn.exec_driver_sql(
+                        'INSERT INTO _td_dst."Overlap" SELECT * FROM main."Overlap" '
+                        "WHERE source_id IN (SELECT node_id FROM _td_selected) "
+                        "AND target_id IN (SELECT node_id FROM _td_selected)"
+                    )
+                    conn.exec_driver_sql('INSERT INTO _td_dst."Metadata" SELECT * FROM main."Metadata"')
                     conn.exec_driver_sql("DROP TABLE _td_selected")
 
                 conn.commit()
             finally:
                 conn.exec_driver_sql("DETACH DATABASE _td_dst")
 
-        # Re-open the destination engine pointing at the now-populated DB.
-        dst._engine = sa.create_engine(dst._url, **dst._engine_kwargs)
-        dst._define_schema(overwrite=False)
-        dst._update_max_id_per_time()
-        dst._node_attr_schemas_cache = None
-        dst._edge_attr_schemas_cache = None
-
-        return dst
+        # 3. Open the destination from the now-populated file. The standard
+        # constructor reflects the schema, restores pickled column types,
+        # and recomputes ``_max_id_per_time``.
+        return cls(**kwargs)
 
     def __getstate__(self) -> dict:
         data_dict = self.__dict__.copy()

--- a/src/tracksdata/graph/_sql_graph.py
+++ b/src/tracksdata/graph/_sql_graph.py
@@ -1103,20 +1103,44 @@ class SQLGraph(BaseGraph):
     ) -> list[list[int, 2]]:
         """
         Get the overlaps between the nodes in `node_ids`.
+
+        When ``node_ids`` is provided, the query is split into chunks to keep
+        the number of bound parameters below the backend's limit (notably
+        SQLite's ``SQLITE_MAX_VARIABLE_NUMBER``).
         """
         if hasattr(node_ids, "tolist"):
             node_ids = node_ids.tolist()
 
         with Session(self._engine) as session:
-            query = session.query(self.Overlap.source_id, self.Overlap.target_id)
+            base_query = session.query(self.Overlap.source_id, self.Overlap.target_id)
 
-            if node_ids is not None:
-                query = query.filter(
-                    self.Overlap.source_id.in_(node_ids),
-                    self.Overlap.target_id.in_(node_ids),
-                )
+            if node_ids is None:
+                return [[source_id, target_id] for source_id, target_id in base_query.all()]
 
-            return [[source_id, target_id] for source_id, target_id in query.all()]
+            if len(node_ids) == 0:
+                return []
+
+            # Split the IN(...) clause into chunks. Each chunk uses 2 * chunk_size
+            # bound parameters (one IN clause per source/target column), so we halve
+            # the chunk size to stay below the backend's limit.
+            chunk_size = max(1, self._sql_chunk_size() // 2)
+            node_id_set = set(node_ids)
+            results: list[list[int]] = []
+            seen: set[tuple[int, int]] = set()
+            for i in range(0, len(node_ids), chunk_size):
+                chunk = node_ids[i : i + chunk_size]
+                # Constrain the source side via the chunk and filter the target side
+                # in Python to avoid an O(N^2) blow-up of bound parameters.
+                query = base_query.filter(self.Overlap.source_id.in_(chunk))
+                for source_id, target_id in query.all():
+                    if target_id not in node_id_set:
+                        continue
+                    key = (source_id, target_id)
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    results.append([source_id, target_id])
+            return results
 
     def has_overlaps(self) -> bool:
         """
@@ -2054,6 +2078,172 @@ class SQLGraph(BaseGraph):
         stmt = sa.select(edge_key_col).group_by(edge_key_col).having(sa.func.count() == 2)
         with Session(self._engine) as session:
             return [int(row[0]) for row in session.execute(stmt).all()]
+
+    @classmethod
+    def from_other(cls: type["SQLGraph"], other: "BaseGraph", **kwargs: Any) -> "SQLGraph":
+        """
+        Create an :class:`SQLGraph` from another graph.
+
+        When the source is also SQL-backed (an :class:`SQLGraph` or a
+        :class:`GraphView` whose root is an :class:`SQLGraph`) and both source
+        and destination use the SQLite driver against on-disk databases, data
+        is copied at the SQL level via ``ATTACH DATABASE`` + ``INSERT INTO ...
+        SELECT`` rather than through Python. This bypasses the generic
+        :meth:`BaseGraph.from_other` path entirely, avoiding both the
+        per-statement variable limit (issue #285) and the cost of
+        materializing the full graph in memory.
+
+        For any other configuration (cross-dialect copy, ``:memory:``
+        destination, non-SQL source) this falls back to the generic
+        implementation.
+        """
+        from tracksdata.graph._graph_view import GraphView
+
+        source_root: SQLGraph | None = None
+        source_node_ids: list[int] | None = None
+
+        if isinstance(other, SQLGraph):
+            source_root = other
+        elif isinstance(other, GraphView) and isinstance(other._root, SQLGraph):
+            source_root = other._root
+            source_node_ids = other.node_ids()
+
+        dst_database = kwargs.get("database")
+        dst_drivername = kwargs.get("drivername", "")
+
+        sqlite_dump_eligible = (
+            source_root is not None
+            and source_root._engine.dialect.name == "sqlite"
+            and isinstance(dst_drivername, str)
+            and dst_drivername.startswith("sqlite")
+            and isinstance(dst_database, str)
+            and dst_database not in ("", ":memory:")
+            and source_root._url.database not in (None, "", ":memory:")
+            and source_root._url.database != dst_database
+        )
+
+        if sqlite_dump_eligible:
+            return cls._sqlite_table_dump(
+                other=other,
+                source_root=source_root,
+                source_node_ids=source_node_ids,
+                kwargs=kwargs,
+            )
+
+        return super().from_other(other, **kwargs)
+
+    @classmethod
+    def _sqlite_table_dump(
+        cls: type["SQLGraph"],
+        *,
+        other: "BaseGraph",
+        source_root: "SQLGraph",
+        source_node_ids: list[int] | None,
+        kwargs: dict[str, Any],
+    ) -> "SQLGraph":
+        """
+        Fast SQLite-to-SQLite copy.
+
+        Steps:
+
+        1. Open the destination :class:`SQLGraph` so it materializes its
+           schema (and metadata) on disk.
+        2. Mirror any extra columns/metadata from the source.
+        3. Dispose the destination engine to release the file handle.
+        4. From the source connection, ``ATTACH`` the destination database
+           and stream rows via ``INSERT INTO _td_dst.\"X\" SELECT ... FROM
+           main.\"X\"``. When a node-id subset is given, the IDs are inserted
+           into a temporary table in chunks and used as a join filter, which
+           sidesteps SQLite's bound-parameter limit.
+        5. Re-open the destination engine and refresh derived state.
+        """
+        dst = cls(**kwargs)
+
+        # Mirror schema extensions onto the destination.
+        for key, schema in other._node_attr_schemas().items():
+            if key not in dst._node_attr_schemas():
+                dst.add_node_attr_key(key, schema.dtype, schema.default_value)
+        for key, schema in other._edge_attr_schemas().items():
+            if key not in dst._edge_attr_schemas():
+                dst.add_edge_attr_key(key, schema.dtype, schema.default_value)
+
+        # Copy metadata before handing off to raw SQL (these go through dst._engine).
+        dst.metadata.update(other.metadata)
+        dst._private_metadata.update(other._private_metadata_for_copy())
+
+        dst_database = dst._url.database
+        dst._engine.dispose()
+
+        node_cols = list(source_root.Node.__table__.columns.keys())
+        edge_cols_no_id = [c for c in source_root.Edge.__table__.columns.keys() if c != DEFAULT_ATTR_KEYS.EDGE_ID]
+        node_cols_sql = ", ".join(f'"{c}"' for c in node_cols)
+        edge_cols_sql = ", ".join(f'"{c}"' for c in edge_cols_no_id)
+
+        chunk_size = max(1, source_root._sql_chunk_size())
+        # ATTACH does not accept bound parameters in every SQLite build; escape
+        # the path safely via single-quote doubling.
+        attach_path = dst_database.replace("'", "''")
+
+        with source_root._engine.connect() as conn:
+            conn.exec_driver_sql(f"ATTACH DATABASE '{attach_path}' AS _td_dst")
+            try:
+                if source_node_ids is None:
+                    conn.exec_driver_sql(
+                        f'INSERT INTO _td_dst."Node" ({node_cols_sql}) SELECT {node_cols_sql} FROM main."Node"'
+                    )
+                    conn.exec_driver_sql(
+                        f'INSERT INTO _td_dst."Edge" ({edge_cols_sql}) SELECT {edge_cols_sql} FROM main."Edge"'
+                    )
+                    conn.exec_driver_sql(
+                        'INSERT INTO _td_dst."Overlap" (source_id, target_id) '
+                        'SELECT source_id, target_id FROM main."Overlap"'
+                    )
+                else:
+                    node_ids = list(source_node_ids)
+                    if hasattr(node_ids, "tolist"):
+                        node_ids = node_ids.tolist()
+                    # Materialize the selection in a temp table so the row
+                    # filter joins instead of using an oversized IN(...) clause.
+                    conn.exec_driver_sql("CREATE TEMP TABLE _td_selected (node_id INTEGER PRIMARY KEY)")
+                    insert_stmt = sa.text("INSERT INTO _td_selected (node_id) VALUES (:node_id)")
+                    for i in range(0, len(node_ids), chunk_size):
+                        batch = node_ids[i : i + chunk_size]
+                        conn.execute(
+                            insert_stmt,
+                            [{"node_id": int(nid)} for nid in batch],
+                        )
+
+                    conn.exec_driver_sql(
+                        f'INSERT INTO _td_dst."Node" ({node_cols_sql}) '
+                        f'SELECT {node_cols_sql} FROM main."Node" '
+                        f"WHERE node_id IN (SELECT node_id FROM _td_selected)"
+                    )
+                    conn.exec_driver_sql(
+                        f'INSERT INTO _td_dst."Edge" ({edge_cols_sql}) '
+                        f'SELECT {edge_cols_sql} FROM main."Edge" '
+                        f"WHERE source_id IN (SELECT node_id FROM _td_selected) "
+                        f"AND target_id IN (SELECT node_id FROM _td_selected)"
+                    )
+                    conn.exec_driver_sql(
+                        'INSERT INTO _td_dst."Overlap" (source_id, target_id) '
+                        'SELECT source_id, target_id FROM main."Overlap" '
+                        "WHERE source_id IN (SELECT node_id FROM _td_selected) "
+                        "AND target_id IN (SELECT node_id FROM _td_selected)"
+                    )
+                    conn.exec_driver_sql("DROP TABLE _td_selected")
+
+                conn.commit()
+            finally:
+                conn.exec_driver_sql("DETACH DATABASE _td_dst")
+
+        # Re-open the destination engine pointing at the now-populated DB.
+        dst._engine = sa.create_engine(dst._url, **dst._engine_kwargs)
+        dst._define_schema(overwrite=False)
+        dst._update_max_id_per_time()
+        dst._node_attr_schemas_cache = None
+        dst._edge_attr_schemas_cache = None
+
+        return dst
 
     def __getstate__(self) -> dict:
         data_dict = self.__dict__.copy()

--- a/src/tracksdata/graph/_test/test_graph_backends.py
+++ b/src/tracksdata/graph/_test/test_graph_backends.py
@@ -2906,3 +2906,221 @@ def test_dividing_nodes(graph_backend: BaseGraph) -> None:
     graph_backend.add_edge(node1, node5, {})
 
     assert set(graph_backend.dividing_nodes()) == {node0, node1}
+
+
+# ---------------------------------------------------------------------------
+# SQLGraph.from_other specialization (issue #285)
+# ---------------------------------------------------------------------------
+
+
+def _populate_sql_graph(graph: SQLGraph, n_per_time: int = 4, n_times: int = 3) -> None:
+    """Populate a graph with nodes, edges, and overlaps for round-trip testing."""
+    graph.add_node_attr_key("x", dtype=pl.Float64)
+    graph.add_node_attr_key("label", dtype=pl.String, default_value="?")
+    graph.add_node_attr_key("blob", dtype=pl.Object, default_value=None)
+    graph.add_edge_attr_key("weight", dtype=pl.Float64, default_value=0.0)
+    graph.add_edge_attr_key("kind", dtype=pl.String, default_value="forward")
+
+    nodes_per_t: list[list[int]] = []
+    for t in range(n_times):
+        ids = []
+        for k in range(n_per_time):
+            node_id = graph.add_node(
+                {
+                    "t": t,
+                    "x": float(t * 10 + k),
+                    "label": f"t{t}_n{k}",
+                    "blob": {"t": t, "k": k},
+                }
+            )
+            ids.append(node_id)
+        nodes_per_t.append(ids)
+
+    # Edges between consecutive time points (full bipartite for some, sparse for others).
+    for t in range(n_times - 1):
+        for src in nodes_per_t[t]:
+            for dst in nodes_per_t[t + 1]:
+                graph.add_edge(
+                    src,
+                    dst,
+                    {"weight": float(src + dst), "kind": "forward" if src <= dst else "skip"},
+                )
+
+    # Overlaps within each time point.
+    for ids in nodes_per_t:
+        for i in range(len(ids)):
+            for j in range(i + 1, len(ids)):
+                graph.add_overlap(ids[i], ids[j])
+
+
+def _assert_graphs_equivalent(src: BaseGraph, dst: BaseGraph) -> None:
+    """Assert that two graphs match in structure, schemas, and overlaps."""
+    assert dst.num_nodes() == src.num_nodes()
+    assert dst.num_edges() == src.num_edges()
+    assert set(dst.node_attr_keys()) == set(src.node_attr_keys())
+    assert set(dst.edge_attr_keys()) == set(src.edge_attr_keys())
+    assert dst._node_attr_schemas() == src._node_attr_schemas()
+    assert dst._edge_attr_schemas() == src._edge_attr_schemas()
+    assert dst.metadata == src.metadata
+
+    # Compare node payloads keyed on (t, x) which is unique in our fixtures.
+    src_nodes = src.node_attrs().sort([DEFAULT_ATTR_KEYS.T, "x"])
+    dst_nodes = dst.node_attrs().sort([DEFAULT_ATTR_KEYS.T, "x"])
+    assert src_nodes.select(["t", "x", "label"]).equals(dst_nodes.select(["t", "x", "label"]))
+
+    # Edge attributes (ignoring auto-generated edge_id ordering).
+    src_edges = src.edge_attrs(attr_keys=["weight", "kind"]).sort(["weight", "kind"])
+    dst_edges = dst.edge_attrs(attr_keys=["weight", "kind"]).sort(["weight", "kind"])
+    assert src_edges.select(["weight", "kind"]).equals(dst_edges.select(["weight", "kind"]))
+
+    src_overlaps = {tuple(sorted(o)) for o in src.overlaps()}
+    dst_overlaps = {tuple(sorted(o)) for o in dst.overlaps()}
+    assert src_overlaps == dst_overlaps
+
+
+def test_sql_from_other_uses_attach_dump_for_sqlite(tmp_path: Path) -> None:
+    """SQLGraph→SQLGraph on disk should use the ATTACH-based fast path and skip
+    the generic BaseGraph copy.
+    """
+    src_db = tmp_path / "src.db"
+    dst_db = tmp_path / "dst.db"
+
+    src = SQLGraph(drivername="sqlite", database=str(src_db))
+    _populate_sql_graph(src, n_per_time=3, n_times=4)
+    src.metadata.update(experiment="issue-285")
+
+    # Spy on the BaseGraph.from_other to confirm we don't fall back to it.
+    from tracksdata.graph import _base_graph as _bg
+
+    base_calls: list[tuple] = []
+    original = _bg.BaseGraph.from_other.__func__
+
+    def _tracking(cls, other, **kwargs):  # type: ignore[no-untyped-def]
+        base_calls.append((cls, type(other).__name__))
+        return original(cls, other, **kwargs)
+
+    _bg.BaseGraph.from_other = classmethod(_tracking)
+    try:
+        dst = SQLGraph.from_other(src, drivername="sqlite", database=str(dst_db))
+    finally:
+        _bg.BaseGraph.from_other = classmethod(original)
+
+    assert base_calls == [], f"specialized path should bypass BaseGraph.from_other, got {base_calls}"
+    assert dst_db.exists()
+    _assert_graphs_equivalent(src, dst)
+    dst._engine.dispose()
+
+
+def test_sql_from_other_subgraph_view_with_overlaps(tmp_path: Path) -> None:
+    """Reproduce issue #285: filtering a SQLGraph then ``from_other`` to a new
+    on-disk SQLGraph must work even when the selection contains many node ids
+    and overlaps.
+    """
+    src_db = tmp_path / "src.db"
+    dst_db = tmp_path / "dst.db"
+
+    src = SQLGraph(drivername="sqlite", database=str(src_db))
+    src.add_node_attr_key("verification_status", dtype=pl.Int32, default_value=0)
+
+    # Force enough nodes to push the overlap query past sqlite's variable limit
+    # if it were submitted as a single IN(...) clause (default 999).
+    n_per_time = 80
+    n_times = 30
+    expected_verified = 0
+    for t in range(n_times):
+        for k in range(n_per_time):
+            status = 1 if (t + k) % 2 == 0 else 0
+            node_id = src.add_node({"t": t, "verification_status": status})
+            if status == 1:
+                expected_verified += 1
+            # Add a few overlaps within each time point.
+            if k > 0:
+                prev = node_id - 1
+                src.add_overlap(prev, node_id)
+
+    assert expected_verified > 999, "test must exceed sqlite's variable limit to be meaningful"
+
+    subgraph = src.filter(NodeAttr("verification_status") == 1).subgraph()
+    dst = SQLGraph.from_other(subgraph, drivername="sqlite", database=str(dst_db))
+
+    assert dst.num_nodes() == expected_verified
+    # Only overlaps between two verified nodes survive.
+    expected_overlaps = {
+        tuple(sorted(o))
+        for o in src.overlaps()
+        if all(src.filter(node_ids=[nid]).node_attrs(attr_keys=["verification_status"]).item(0, 0) == 1 for nid in o)
+    }
+    actual_overlaps = {tuple(sorted(o)) for o in dst.overlaps()}
+    assert actual_overlaps == expected_overlaps
+    dst._engine.dispose()
+
+
+def test_sql_from_other_full_copy_preserves_node_ids(tmp_path: Path) -> None:
+    """The fast SQLite path must preserve node ids for full copies."""
+    src_db = tmp_path / "src.db"
+    dst_db = tmp_path / "dst.db"
+
+    src = SQLGraph(drivername="sqlite", database=str(src_db))
+    _populate_sql_graph(src, n_per_time=2, n_times=3)
+
+    dst = SQLGraph.from_other(src, drivername="sqlite", database=str(dst_db))
+
+    assert sorted(dst.node_ids()) == sorted(src.node_ids())
+    dst._engine.dispose()
+
+
+def test_sql_from_other_falls_back_for_in_memory_destination() -> None:
+    """`:memory:` destinations cannot be ATTACHed across connections, so the
+    generic path must still be used.
+    """
+    src = SQLGraph(drivername="sqlite", database=":memory:")
+    _populate_sql_graph(src, n_per_time=2, n_times=2)
+
+    dst = SQLGraph.from_other(
+        src,
+        drivername="sqlite",
+        database=":memory:",
+        engine_kwargs={"connect_args": {"check_same_thread": False}},
+    )
+
+    _assert_graphs_equivalent(src, dst)
+
+
+def test_sql_from_other_falls_back_for_non_sql_source(tmp_path: Path) -> None:
+    """A non-SQL source must still produce a populated SQLGraph via the base path."""
+    src = RustWorkXGraph()
+    src.add_node_attr_key("x", dtype=pl.Float64)
+    n0 = src.add_node({"t": 0, "x": 1.0})
+    n1 = src.add_node({"t": 1, "x": 2.0})
+    src.add_edge(n0, n1, {})
+    src.add_overlap(n0, n0)  # self-overlap is allowed by the API
+
+    dst = SQLGraph.from_other(src, drivername="sqlite", database=str(tmp_path / "dst.db"))
+    assert dst.num_nodes() == src.num_nodes()
+    assert dst.num_edges() == src.num_edges()
+    assert {tuple(sorted(o)) for o in dst.overlaps()} == {tuple(sorted(o)) for o in src.overlaps()}
+    dst._engine.dispose()
+
+
+def test_sql_overlaps_chunks_large_node_id_filter(tmp_path: Path) -> None:
+    """`SQLGraph.overlaps(node_ids=...)` must not hit the bound-parameter limit."""
+    db_path = tmp_path / "g.db"
+    graph = SQLGraph(drivername="sqlite", database=str(db_path))
+
+    # Add enough nodes for the IN(...) clause to overflow if not chunked.
+    pairs = []
+    for t in range(20):
+        last = None
+        for _ in range(120):
+            current = graph.add_node({"t": t})
+            if last is not None:
+                graph.add_overlap(last, current)
+                pairs.append(tuple(sorted((last, current))))
+            last = current
+
+    all_node_ids = graph.node_ids()
+    assert len(all_node_ids) > 999  # exceed the default sqlite variable limit
+
+    overlaps = graph.overlaps(node_ids=all_node_ids)
+    assert {tuple(sorted(o)) for o in overlaps} == set(pairs)
+    graph._engine.dispose()

--- a/src/tracksdata/graph/_test/test_graph_backends.py
+++ b/src/tracksdata/graph/_test/test_graph_backends.py
@@ -1,4 +1,5 @@
 import datetime as dt
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -2977,6 +2978,9 @@ def _assert_graphs_equivalent(src: BaseGraph, dst: BaseGraph) -> None:
     dst_overlaps = {tuple(sorted(o)) for o in dst.overlaps()}
     assert src_overlaps == dst_overlaps
 
+    # Node ids are preserved because both backends support custom indices.
+    assert sorted(dst.node_ids()) == sorted(src.node_ids())
+
 
 def test_sql_from_other_uses_attach_dump_for_sqlite(tmp_path: Path) -> None:
     """SQLGraph→SQLGraph on disk should use the ATTACH-based fast path and skip
@@ -3011,15 +3015,41 @@ def test_sql_from_other_uses_attach_dump_for_sqlite(tmp_path: Path) -> None:
     dst._engine.dispose()
 
 
-def test_sql_from_other_subgraph_view_with_overlaps(tmp_path: Path) -> None:
-    """Reproduce issue #285: filtering a SQLGraph then ``from_other`` to a new
+def _make_sql_disk_source(tmp_path: Path) -> BaseGraph:
+    return SQLGraph(drivername="sqlite", database=str(tmp_path / "src.db"))
+
+
+def _make_sql_memory_source(tmp_path: Path) -> BaseGraph:
+    return SQLGraph(
+        drivername="sqlite",
+        database=":memory:",
+        engine_kwargs={"connect_args": {"check_same_thread": False}},
+    )
+
+
+def _make_rustworkx_source(tmp_path: Path) -> BaseGraph:
+    return RustWorkXGraph()
+
+
+@pytest.mark.parametrize(
+    "make_source",
+    [
+        pytest.param(_make_sql_disk_source, id="sql-disk"),
+        pytest.param(_make_sql_memory_source, id="sql-memory"),
+        pytest.param(_make_rustworkx_source, id="rustworkx"),
+    ],
+)
+def test_sql_from_other_subgraph_view_with_overlaps(
+    make_source: Callable[[Path], BaseGraph],
+    tmp_path: Path,
+) -> None:
+    """Reproduce issue #285: filtering a graph then ``from_other`` to a new
     on-disk SQLGraph must work even when the selection contains many node ids
-    and overlaps.
+    and overlaps, regardless of the source backend.
     """
-    src_db = tmp_path / "src.db"
     dst_db = tmp_path / "dst.db"
 
-    src = SQLGraph(drivername="sqlite", database=str(src_db))
+    src = make_source(tmp_path)
     src.add_node_attr_key("verification_status", dtype=pl.Int32, default_value=0)
 
     # Force enough nodes to push the overlap query past sqlite's variable limit
@@ -3052,20 +3082,6 @@ def test_sql_from_other_subgraph_view_with_overlaps(tmp_path: Path) -> None:
     }
     actual_overlaps = {tuple(sorted(o)) for o in dst.overlaps()}
     assert actual_overlaps == expected_overlaps
-    dst._engine.dispose()
-
-
-def test_sql_from_other_full_copy_preserves_node_ids(tmp_path: Path) -> None:
-    """The fast SQLite path must preserve node ids for full copies."""
-    src_db = tmp_path / "src.db"
-    dst_db = tmp_path / "dst.db"
-
-    src = SQLGraph(drivername="sqlite", database=str(src_db))
-    _populate_sql_graph(src, n_per_time=2, n_times=3)
-
-    dst = SQLGraph.from_other(src, drivername="sqlite", database=str(dst_db))
-
-    assert sorted(dst.node_ids()) == sorted(src.node_ids())
     dst._engine.dispose()
 
 


### PR DESCRIPTION
Closes #285.

`BaseGraph.from_other` ends with `other.overlaps()`, which on a SQL-rooted `GraphView` issues a single `IN (...)` containing every selected node id and overflows SQLite's variable limit.

This PR adds a SQL-level fast path on `SQLGraph.from_other`: when both ends are on-disk SQLite, the source's schema and rows are dumped straight into the destination via `ATTACH DATABASE` + replayed `CREATE TABLE/INDEX` DDL + `INSERT INTO ... SELECT`, then the destination is opened from the populated file. Filtered selections (`GraphView`) are joined against a temp table to sidestep the bound-parameter limit. Other configurations fall back to the generic path.

Separately, `SQLGraph.overlaps(node_ids)` is now chunked via the existing `_chunked_sa_read` helper so direct callers don't hit the same limit.

Tests cover the fast path, the issue reproducer (filter → subgraph → from_other with > 999 nodes + overlaps), full-copy id preservation, and fallbacks for `:memory:` and non-SQL sources.