### PR TITLE
ci: use uv.lock to avoid zarr 2 + numcodecs 0.16 clash on Py3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        uv sync --extra test
+        uv sync --locked --extra test
 
     - name: Run tests with coverage
       uses: aganders3/headless-gui@v2


### PR DESCRIPTION
Without `--locked`, CI re-resolves and on Python 3.11 picks `zarr==2.18.3` + `numcodecs==0.16.5`. New numcodecs dropped `cbuffer_sizes`/`cbuffer_metainfo`, which zarr 2.x's `util.py` imports at module load — so any `import zarr` (e.g. via `geff_spec`) ImportErrors and tests are cancelled.

The committed `uv.lock` already pins the working pair (`zarr==3.1.1` + `numcodecs==0.15.1` on Py3.11). Pass `--locked` so CI honors it instead of re-resolving. No project dependencies pinned.