### PR TITLE
Require zarr>=3 on Python >= 3.11 to fix numcodecs 0.16 clash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,12 @@ dependencies = [
   "bidict>=0.23.1",
   "geff>=1.1.3.1.1",
   "psygnal>=0.14.0",
+  # zarr 2.x's util.py imports cbuffer_sizes/cbuffer_metainfo from
+  # numcodecs.blosc, which numcodecs >= 0.16 removed. On Python 3.10 the
+  # resolver is forced to numcodecs <= 0.13 (numcodecs >= 0.14 needs
+  # Python >= 3.11), so zarr 2.18 still imports there. On Python >= 3.11
+  # nothing prevents the broken pair, so require zarr >= 3 explicitly.
+  "zarr>=3; python_version >= '3.11'",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
On Python 3.11+ the resolver freely picks `zarr==2.18.x` together with `numcodecs>=0.16`. Newer numcodecs dropped `cbuffer_sizes`/`cbuffer_metainfo`, which zarr 2.x's `util.py` imports at module load — so `import zarr` (e.g. via `geff_spec`) ImportErrors and CI tests are cancelled. End users hit the same bug with `pip install` on Py3.11.

On Py3.10 the resolver is forced to `numcodecs<=0.13` (newer numcodecs requires Py>=3.11), so the broken pair is unreachable and zarr 2.18 keeps working there.

Marker-gated lower bound on zarr that only constrains the affected Python versions. Our code already imports zarr v3 APIs (`from zarr.storage import StoreLike`), so this just makes explicit what we already require.