### PR TITLE
Remove only on view

### DIFF
--- a/benchmarks/graph_mutations.py
+++ b/benchmarks/graph_mutations.py
@@ -30,6 +30,10 @@ N_OPS = 50
 N_LINEAGES = 50
 
 
+def _noop(*_args) -> None:
+    """No-op slot to enable the `node_updated` signal-payload path in benchmarks."""
+
+
 def _build_graph(backend_name: str, n_nodes: int) -> td.graph.BaseGraph:
     graph = BACKENDS[backend_name]()
     graph.add_node_attr_key("score", dtype=pl.Float64)
@@ -60,6 +64,16 @@ class GraphMutationsBenchmark:
         self.removal_targets = all_ids[:N_OPS]
         self.update_targets = all_ids[: N_OPS * 4]
 
+        # Separate view with a no-op listener attached. Without a listener,
+        # update_node_attrs skips the signal-payload computation entirely, so
+        # the P2-2 optimization (deriving new_attrs from old + applied) isn't
+        # exercised. This view is the BBoxSpatialFilter / GraphArrayView use case.
+        self.listened_view = self.graph.filter().subgraph()
+        self.listened_view.node_updated.connect(_noop)
+        # Smaller batch, representative of interactive editing where the saved
+        # query overhead is a larger fraction of the total work.
+        self.listener_update_targets = all_ids[:N_OPS]
+
     # --- remove_node ------------------------------------------------------
 
     def time_remove_node_root(self, backend_name: str, n_nodes: int) -> None:
@@ -77,6 +91,9 @@ class GraphMutationsBenchmark:
 
     def time_update_node_attrs_view(self, backend_name: str, n_nodes: int) -> None:
         self.view.update_node_attrs(node_ids=self.update_targets, attrs={"score": 1.0})
+
+    def time_update_node_attrs_view_with_listener(self, backend_name: str, n_nodes: int) -> None:
+        self.listened_view.update_node_attrs(node_ids=self.listener_update_targets, attrs={"score": 1.0})
 
     # --- filter (standalone, materialized to ids) ------------------------
 

--- a/src/tracksdata/graph/_graph_view.py
+++ b/src/tracksdata/graph/_graph_view.py
@@ -522,9 +522,7 @@ class GraphView(MappedGraphMixin, RustWorkXGraph):
         if node_id not in self._external_to_local:
             raise ValueError(f"Node {node_id} does not exist in the graph.")
         if not self.sync:
-            raise RuntimeError(
-                "remove_node_from_view requires sync=True; the local view is not maintained otherwise."
-            )
+            raise RuntimeError("remove_node_from_view requires sync=True; the local view is not maintained otherwise.")
 
         view_signal_on = is_signal_on(self.node_removed)
         if view_signal_on:
@@ -661,9 +659,7 @@ class GraphView(MappedGraphMixin, RustWorkXGraph):
             If `sync=False` — view-only removal requires a maintained local view.
         """
         if not self.sync:
-            raise RuntimeError(
-                "remove_edge_from_view requires sync=True; the local view is not maintained otherwise."
-            )
+            raise RuntimeError("remove_edge_from_view requires sync=True; the local view is not maintained otherwise.")
 
         if edge_id is None:
             if source_id is None or target_id is None:

--- a/src/tracksdata/graph/_graph_view.py
+++ b/src/tracksdata/graph/_graph_view.py
@@ -2,6 +2,7 @@ from collections.abc import Callable, Sequence
 from typing import Any, Literal, cast, overload
 
 import bidict
+import numpy as np
 import polars as pl
 import rustworkx as rx
 
@@ -737,12 +738,18 @@ class GraphView(MappedGraphMixin, RustWorkXGraph):
                 self._out_of_sync = True
 
         if view_signal_on or root_signal_on:
-            new_attrs_by_id = (
-                self._root.filter(node_ids=node_ids)
-                .node_attrs(attr_keys=signal_keys)
-                .rows_by_key(key=DEFAULT_ATTR_KEYS.NODE_ID, named=True, unique=True, include_key=True)
-            )
             old_attrs_by_id = cast(dict[int, dict[str, Any]], old_attrs_by_id)  # for mypy
+            # Derive new_attrs by overlaying applied `attrs` onto old_attrs, instead of
+            # re-querying root. Mirrors the broadcasting semantics of
+            # `_root.update_node_attrs`: scalars apply to all nodes, sequences index by
+            # position in `node_ids`.
+            new_attrs_by_id: dict[int, dict[str, Any]] = {}
+            for i, node_id in enumerate(node_ids):
+                new_attrs = dict(old_attrs_by_id[node_id])
+                for k, v in attrs.items():
+                    if k in new_attrs:
+                        new_attrs[k] = v if np.isscalar(v) else v[i]
+                new_attrs_by_id[node_id] = new_attrs
             if root_signal_on:
                 for node_id in node_ids:
                     self._root.node_updated.emit(

--- a/src/tracksdata/graph/_graph_view.py
+++ b/src/tracksdata/graph/_graph_view.py
@@ -429,6 +429,29 @@ class GraphView(MappedGraphMixin, RustWorkXGraph):
 
         return parent_node_ids
 
+    def _remove_node_local(self, node_id: int) -> None:
+        """
+        Remove a node from this view's local rx_graph and ID mappings only.
+
+        No validation, no signals, no root call. Caller is responsible for those.
+        """
+        local_node_id = self._external_to_local[node_id]
+
+        # Capture incident edges BEFORE removal. rustworkx drops them along with
+        # the node; afterwards we'd have no way to identify which entries to
+        # clean from `_edge_map_to_root` without scanning the whole bookkeeping.
+        # `all_edges=True` is required — the default returns only out-edges,
+        # which would leave in-edge bookkeeping stale.
+        incident_local_edge_ids = list(self.rx_graph.incident_edges(local_node_id, all_edges=True))
+
+        with self.node_removed.blocked():
+            super().remove_node(local_node_id)
+
+        self._remove_id_mapping(external_id=node_id)
+
+        for edge_id in incident_local_edge_ids:
+            self._edge_map_to_root.pop(edge_id, None)
+
     def remove_node(self, node_id: int) -> None:
         """
         Remove a node from the graph.
@@ -463,28 +486,52 @@ class GraphView(MappedGraphMixin, RustWorkXGraph):
             self._root.remove_node(node_id)
 
         if self.sync:
-            # Get the local node ID and remove from local graph
-            local_node_id = self._external_to_local[node_id]
-
-            # Capture incident edges BEFORE removal. rustworkx drops them along with
-            # the node; afterwards we'd have no way to identify which entries to
-            # clean from `_edge_map_to_root` without scanning the whole bookkeeping.
-            incident_local_edge_ids = list(self.rx_graph.incident_edges(local_node_id))
-
-            with self.node_removed.blocked():
-                super().remove_node(local_node_id)
-
-            # Remove the node mapping
-            self._remove_id_mapping(external_id=node_id)
-
-            # Drop just the affected edges from the bookkeeping
-            for edge_id in incident_local_edge_ids:
-                self._edge_map_to_root.pop(edge_id, None)
+            self._remove_node_local(node_id)
         else:
             self._out_of_sync = True
 
         if root_signal_on:
             self._root.node_removed.emit(node_id, old_attrs)
+        if view_signal_on:
+            self.node_removed.emit(node_id, old_attrs)
+
+    def remove_node_from_view(self, node_id: int) -> None:
+        """
+        Remove a node from this view only, leaving the root graph untouched.
+
+        The view's local rx_graph and ID mappings are updated; the root is not
+        modified. After this call the view no longer represents a strict filter
+        of the root, but its internal state is consistent and traversals
+        (successors/predecessors) continue to work.
+
+        Only the view's `node_removed` signal fires — the root signal does not,
+        because the root did not change.
+
+        Parameters
+        ----------
+        node_id : int
+            The ID of the node to remove from the view.
+
+        Raises
+        ------
+        ValueError
+            If the node_id does not exist in the view.
+        RuntimeError
+            If `sync=False` — view-only removal requires a maintained local view.
+        """
+        if node_id not in self._external_to_local:
+            raise ValueError(f"Node {node_id} does not exist in the graph.")
+        if not self.sync:
+            raise RuntimeError(
+                "remove_node_from_view requires sync=True; the local view is not maintained otherwise."
+            )
+
+        view_signal_on = is_signal_on(self.node_removed)
+        if view_signal_on:
+            old_attrs = self.nodes[node_id].to_dict()
+
+        self._remove_node_local(node_id)
+
         if view_signal_on:
             self.node_removed.emit(node_id, old_attrs)
 
@@ -542,6 +589,18 @@ class GraphView(MappedGraphMixin, RustWorkXGraph):
         if return_ids:
             return parent_edge_ids
 
+    def _remove_edge_local(self, edge_id: int) -> None:
+        """
+        Remove an edge from this view's local rx_graph and edge mapping only.
+
+        No validation, no root call. Caller guarantees `edge_id` (root id) is
+        present in `self._edge_map_from_root`.
+        """
+        local_edge_id = self._edge_map_from_root[edge_id]
+        src, tgt, _ = self.rx_graph.edge_index_map()[local_edge_id]
+        self.rx_graph.remove_edge(src, tgt)
+        del self._edge_map_to_root[local_edge_id]
+
     def remove_edge(
         self,
         source_id: int | None = None,
@@ -566,13 +625,58 @@ class GraphView(MappedGraphMixin, RustWorkXGraph):
         # Remove from the local graph if synced
         if self.sync:
             if edge_id in self._edge_map_from_root:
-                local_edge_id = self._edge_map_from_root[edge_id]
-                edge_map = self.rx_graph.edge_index_map()
-                src, tgt, _ = edge_map[local_edge_id]
-                self.rx_graph.remove_edge(src, tgt)
-                del self._edge_map_to_root[local_edge_id]
+                self._remove_edge_local(edge_id)
         else:
             self._out_of_sync = True
+
+    def remove_edge_from_view(
+        self,
+        source_id: int | None = None,
+        target_id: int | None = None,
+        *,
+        edge_id: int | None = None,
+    ) -> None:
+        """
+        Remove an edge from this view only, leaving the root graph untouched.
+
+        Resolves the edge by `edge_id` or by `(source_id, target_id)`. The root
+        graph is not modified, so the view will diverge from a strict filter of
+        the root.
+
+        Parameters
+        ----------
+        source_id : int, optional
+            Source node id of the edge. Required if `edge_id` is not given.
+        target_id : int, optional
+            Target node id of the edge. Required if `edge_id` is not given.
+        edge_id : int, optional
+            Root edge id. If given, `source_id` and `target_id` are ignored.
+
+        Raises
+        ------
+        ValueError
+            If neither `edge_id` nor both endpoints are given, or the edge is
+            not in the view.
+        RuntimeError
+            If `sync=False` — view-only removal requires a maintained local view.
+        """
+        if not self.sync:
+            raise RuntimeError(
+                "remove_edge_from_view requires sync=True; the local view is not maintained otherwise."
+            )
+
+        if edge_id is None:
+            if source_id is None or target_id is None:
+                raise ValueError("Provide either edge_id or both source_id and target_id.")
+            try:
+                edge_id = self._root.edge_id(source_id, target_id)
+            except rx.NoEdgeBetweenNodes as e:
+                raise ValueError(f"Edge {source_id}->{target_id} does not exist in the graph.") from e
+
+        if edge_id not in self._edge_map_from_root:
+            raise ValueError(f"Edge {edge_id} does not exist in the view.")
+
+        self._remove_edge_local(edge_id)
 
     def _get_neighbors(
         self,

--- a/src/tracksdata/graph/_graph_view.py
+++ b/src/tracksdata/graph/_graph_view.py
@@ -465,23 +465,20 @@ class GraphView(MappedGraphMixin, RustWorkXGraph):
             # Get the local node ID and remove from local graph
             local_node_id = self._external_to_local[node_id]
 
+            # Capture incident edges BEFORE removal. rustworkx drops them along with
+            # the node; afterwards we'd have no way to identify which entries to
+            # clean from `_edge_map_to_root` without scanning the whole bookkeeping.
+            incident_local_edge_ids = list(self.rx_graph.incident_edges(local_node_id))
+
             with self.node_removed.blocked():
                 super().remove_node(local_node_id)
 
             # Remove the node mapping
             self._remove_id_mapping(external_id=node_id)
 
-            # Update edge mappings - remove edges involving this node
-            edges_to_remove = []
-            edge_indices = self.rx_graph.edge_indices()
-            for local_edge_id, _ in list(self._edge_map_to_root.items()):
-                # Check if this edge is still in the local graph
-                if local_edge_id not in edge_indices:
-                    edges_to_remove.append(local_edge_id)
-
-            for edge_id in edges_to_remove:
-                if edge_id in self._edge_map_to_root:
-                    del self._edge_map_to_root[edge_id]
+            # Drop just the affected edges from the bookkeeping
+            for edge_id in incident_local_edge_ids:
+                self._edge_map_to_root.pop(edge_id, None)
         else:
             self._out_of_sync = True
 

--- a/src/tracksdata/graph/_graph_view.py
+++ b/src/tracksdata/graph/_graph_view.py
@@ -533,6 +533,68 @@ class GraphView(MappedGraphMixin, RustWorkXGraph):
         if view_signal_on:
             self.node_removed.emit(node_id, old_attrs)
 
+    def _add_node_local(self, node_id: int) -> None:
+        """
+        Re-insert a node that already exists in the root into this view's local
+        rx_graph and ID mappings only. No root call, no signals.
+
+        Caller guarantees `node_id` exists in the root and is not already in the view.
+
+        The attributes are obtained the same way ``subgraph()`` does for the backend:
+        for an in-memory (rustworkx-family) root the root's attribute dict is reused by
+        reference (so root↔view writes propagate without an explicit sync); for any other
+        backend (e.g. ``SQLGraph``) a fresh attribute dict is fetched via the public API,
+        matching that backend's copy-on-subgraph semantics. Inverse of
+        ``_remove_node_local``.
+        """
+        root = self._root
+        if hasattr(root, "rx_graph"):
+            root_local_id = root._map_to_local(node_id) if hasattr(root, "_map_to_local") else node_id
+            attrs = root.rx_graph[root_local_id]
+        else:
+            attrs = root.filter(node_ids=[node_id]).node_attrs().drop(DEFAULT_ATTR_KEYS.NODE_ID).rows(named=True)[0]
+
+        with self.node_added.blocked():
+            local_node_id = RustWorkXGraph.add_node(self, attrs, validate_keys=False)
+
+        self._add_id_mapping(local_node_id, node_id)
+
+    def add_node_to_view(self, node_id: int) -> None:
+        """
+                Re-surface a node that exists in the root into this view only, leaving the
+                root graph untouched. Inverse of ``remove_node_from_view``.
+        f
+                The node must exist in the root and must not already be in the view. Its
+                attributes follow the same sharing semantics as ``subgraph()`` for the backend
+                (shared by reference for rustworkx-family roots, copied for others). Incident
+                edges are NOT re-added — use ``add_edge_to_view`` for those.
+
+                Only the view's ``node_added`` signal fires — the root did not change.
+
+                Parameters
+                ----------
+                node_id : int
+                    The (root) ID of the node to re-surface in the view.
+
+                Raises
+                ------
+                ValueError
+                    If the node is already in the view, or does not exist in the root.
+                RuntimeError
+                    If ``sync=False`` — view-only mutation requires a maintained local view.
+        """
+        if not self.sync:
+            raise RuntimeError("add_node_to_view requires sync=True; the local view is not maintained otherwise.")
+        if node_id in self._external_to_local:
+            raise ValueError(f"Node {node_id} is already in the view.")
+        if not self._root.has_node(node_id):
+            raise ValueError(f"Node {node_id} does not exist in the root graph.")
+
+        self._add_node_local(node_id)
+
+        if is_signal_on(self.node_added):
+            self.node_added.emit(node_id, self.nodes[node_id].to_dict())
+
     def add_edge(
         self,
         source_id: int,
@@ -673,6 +735,87 @@ class GraphView(MappedGraphMixin, RustWorkXGraph):
             raise ValueError(f"Edge {edge_id} does not exist in the view.")
 
         self._remove_edge_local(edge_id)
+
+    def _add_edge_local(self, source_id: int, target_id: int) -> int:
+        """
+        Re-insert an edge that already exists in the root into this view's local
+        rx_graph and edge mapping only. No root call. Returns the root edge id.
+
+        Caller guarantees the root edge ``source_id -> target_id`` exists and both
+        endpoints are already in the view. Attributes are obtained the same way
+        ``subgraph()`` does for the backend: reused by reference for an in-memory
+        (rustworkx-family) root, or fetched as a fresh dict via the public API for any
+        other backend (e.g. ``SQLGraph``). Inverse of ``_remove_edge_local``.
+        """
+        parent_edge_id = self._root.edge_id(source_id, target_id)
+
+        root = self._root
+        if hasattr(root, "rx_graph"):
+            root_local_src = root._map_to_local(source_id) if hasattr(root, "_map_to_local") else source_id
+            root_local_tgt = root._map_to_local(target_id) if hasattr(root, "_map_to_local") else target_id
+            attrs = root.rx_graph.get_edge_data(root_local_src, root_local_tgt)
+        else:
+            df = root.edge_attrs()
+            drop_cols = [
+                c
+                for c in (
+                    DEFAULT_ATTR_KEYS.EDGE_ID,
+                    DEFAULT_ATTR_KEYS.EDGE_SOURCE,
+                    DEFAULT_ATTR_KEYS.EDGE_TARGET,
+                )
+                if c in df.columns
+            ]
+            attrs = df.filter(pl.col(DEFAULT_ATTR_KEYS.EDGE_ID) == parent_edge_id).drop(drop_cols).rows(named=True)[0]
+
+        local_edge_id = self.rx_graph.add_edge(
+            self._map_to_local(source_id),
+            self._map_to_local(target_id),
+            attrs,
+        )
+        self._edge_map_to_root.put(local_edge_id, parent_edge_id)
+        return parent_edge_id
+
+    def add_edge_to_view(
+        self,
+        source_id: int,
+        target_id: int,
+    ) -> None:
+        """
+        Re-surface an edge that exists in the root into this view only, leaving the
+        root graph untouched. Inverse of ``remove_edge_from_view``.
+
+        Both endpoints must already be in the view, the root edge must exist, and the
+        edge must not already be in the view. The edge's attributes follow the same
+        sharing semantics as ``subgraph()`` for the backend (shared by reference for
+        rustworkx-family roots, copied for others). No ``edge_added`` signal exists, so
+        (as with the edge-remove helper) edges have no signal analog.
+
+        Parameters
+        ----------
+        source_id, target_id : int
+            Endpoints of the (root) edge to re-surface in the view.
+
+        Raises
+        ------
+        ValueError
+            If an endpoint is missing from the view, the root edge does not exist, or
+            the edge is already in the view.
+        RuntimeError
+            If ``sync=False`` — view-only mutation requires a maintained local view.
+        """
+        if not self.sync:
+            raise RuntimeError("add_edge_to_view requires sync=True; the local view is not maintained otherwise.")
+        for endpoint in (source_id, target_id):
+            if endpoint not in self._external_to_local:
+                raise ValueError(f"Endpoint {endpoint} is not in the view.")
+        try:
+            parent_edge_id = self._root.edge_id(source_id, target_id)
+        except rx.NoEdgeBetweenNodes as e:
+            raise ValueError(f"Edge {source_id}->{target_id} does not exist in the root graph.") from e
+        if parent_edge_id in self._edge_map_from_root:
+            raise ValueError(f"Edge {source_id}->{target_id} is already in the view.")
+
+        self._add_edge_local(source_id, target_id)
 
     def _get_neighbors(
         self,

--- a/src/tracksdata/graph/_test/test_subgraph.py
+++ b/src/tracksdata/graph/_test/test_subgraph.py
@@ -1143,6 +1143,165 @@ def test_graph_view_remove_edge(graph_backend: BaseGraph) -> None:
         view.remove_edge()
 
 
+def test_remove_node_from_view_basic(graph_backend: BaseGraph) -> None:
+    """`remove_node_from_view` drops the node from the view but leaves the root untouched."""
+    graph_backend.add_node_attr_key("x", pl.Float64)
+    graph_backend.add_edge_attr_key("weight", pl.Float64)
+
+    n0 = graph_backend.add_node({"t": 0, "x": 0.0})
+    n1 = graph_backend.add_node({"t": 1, "x": 1.0})
+    n2 = graph_backend.add_node({"t": 2, "x": 2.0})
+    graph_backend.add_edge(n0, n1, {"weight": 0.2})
+    graph_backend.add_edge(n1, n2, {"weight": 0.8})
+
+    view = graph_backend.filter().subgraph()
+    assert isinstance(view, GraphView)
+
+    view.remove_node_from_view(n1)
+
+    # View no longer has the node or its incident edges
+    assert n1 not in view.node_ids()
+    assert not view.has_node(n1)
+    assert not view.has_edge(n0, n1)
+    assert not view.has_edge(n1, n2)
+
+    # Edge bookkeeping is cleaned in the view
+    view_edge_root_ids = set(view._edge_map_to_root.values())
+    assert graph_backend.edge_id(n0, n1) not in view_edge_root_ids
+    assert graph_backend.edge_id(n1, n2) not in view_edge_root_ids
+
+    # Root is untouched
+    assert n1 in graph_backend.node_ids()
+    assert graph_backend.has_node(n1)
+    assert graph_backend.has_edge(n0, n1)
+    assert graph_backend.has_edge(n1, n2)
+
+
+def test_remove_node_from_view_traversals_still_work(graph_backend: BaseGraph) -> None:
+    """`_out_of_sync` is not set: successors/predecessors still work after view-only removal."""
+    graph_backend.add_node_attr_key("x", pl.Float64)
+    n0 = graph_backend.add_node({"t": 0, "x": 0.0})
+    n1 = graph_backend.add_node({"t": 1, "x": 1.0})
+    n2 = graph_backend.add_node({"t": 2, "x": 2.0})
+    graph_backend.add_edge(n0, n1, {})
+    graph_backend.add_edge(n1, n2, {})
+
+    view = graph_backend.filter().subgraph()
+    view.remove_node_from_view(n1)
+
+    assert view._out_of_sync is False
+    # Should not raise
+    view.successors(n0)
+    view.predecessors(n2)
+
+
+def test_remove_node_from_view_signals(graph_backend: BaseGraph) -> None:
+    """Only the view's `node_removed` fires; the root's signal does not."""
+    graph_backend.add_node_attr_key("x", pl.Float64)
+    n0 = graph_backend.add_node({"t": 0, "x": 0.0})
+    n1 = graph_backend.add_node({"t": 1, "x": 1.0})
+
+    view = graph_backend.filter().subgraph()
+
+    view_calls: list[tuple[int, dict]] = []
+    root_calls: list[tuple[int, dict]] = []
+    view.node_removed.connect(lambda nid, attrs: view_calls.append((nid, attrs)))
+    graph_backend.node_removed.connect(lambda nid, attrs: root_calls.append((nid, attrs)))
+
+    view.remove_node_from_view(n1)
+
+    assert len(root_calls) == 0
+    assert len(view_calls) == 1
+    assert view_calls[0][0] == n1
+    assert view_calls[0][1]["x"] == 1.0
+    # Root still has the node — the view-only removal did not touch it
+    assert graph_backend.has_node(n1)
+    # n0 is unaffected
+    _ = n0
+
+
+def test_remove_node_from_view_validation(graph_backend: BaseGraph) -> None:
+    """Missing node raises ValueError; sync=False raises RuntimeError."""
+    graph_backend.add_node_attr_key("x", pl.Float64)
+    n0 = graph_backend.add_node({"t": 0, "x": 0.0})
+
+    view = graph_backend.filter().subgraph()
+
+    with pytest.raises(ValueError, match=r"Node 999999 does not exist in the graph\."):
+        view.remove_node_from_view(999999)
+
+    view.sync = False
+    with pytest.raises(RuntimeError, match=r"remove_node_from_view requires sync=True"):
+        view.remove_node_from_view(n0)
+
+
+def test_remove_edge_from_view_basic(graph_backend: BaseGraph) -> None:
+    """`remove_edge_from_view` drops the edge from the view but leaves the root edge intact."""
+    graph_backend.add_node_attr_key("x", pl.Float64)
+    graph_backend.add_edge_attr_key("weight", pl.Float64)
+
+    n0 = graph_backend.add_node({"t": 0, "x": 0.0})
+    n1 = graph_backend.add_node({"t": 1, "x": 1.0})
+    n2 = graph_backend.add_node({"t": 2, "x": 2.0})
+    graph_backend.add_edge(n0, n1, {"weight": 0.2})
+    graph_backend.add_edge(n1, n2, {"weight": 0.8})
+
+    # Remove by endpoints
+    view = graph_backend.filter().subgraph()
+    view.remove_edge_from_view(n0, n1)
+    assert not view.has_edge(n0, n1)
+    assert graph_backend.has_edge(n0, n1)
+    # Other edge unaffected
+    assert view.has_edge(n1, n2)
+
+    # Remove by edge_id on a fresh view
+    view2 = graph_backend.filter().subgraph()
+    eid = graph_backend.edge_id(n1, n2)
+    view2.remove_edge_from_view(edge_id=eid)
+    assert not view2.has_edge(n1, n2)
+    assert graph_backend.has_edge(n1, n2)
+
+
+def test_remove_edge_from_view_traversals_still_work(graph_backend: BaseGraph) -> None:
+    """`_out_of_sync` stays False after view-only edge removal."""
+    graph_backend.add_node_attr_key("x", pl.Float64)
+    n0 = graph_backend.add_node({"t": 0, "x": 0.0})
+    n1 = graph_backend.add_node({"t": 1, "x": 1.0})
+    graph_backend.add_edge(n0, n1, {})
+
+    view = graph_backend.filter().subgraph()
+    view.remove_edge_from_view(n0, n1)
+
+    assert view._out_of_sync is False
+    view.successors(n0)
+    view.predecessors(n1)
+
+
+def test_remove_edge_from_view_validation(graph_backend: BaseGraph) -> None:
+    """Bad inputs raise ValueError; sync=False raises RuntimeError."""
+    graph_backend.add_node_attr_key("x", pl.Float64)
+    n0 = graph_backend.add_node({"t": 0, "x": 0.0})
+    n1 = graph_backend.add_node({"t": 1, "x": 1.0})
+    graph_backend.add_edge(n0, n1, {})
+
+    view = graph_backend.filter().subgraph()
+
+    with pytest.raises(ValueError, match=r"Provide either edge_id or both source_id and target_id\."):
+        view.remove_edge_from_view()
+
+    # Non-existent endpoints
+    with pytest.raises(ValueError, match=rf"Edge {n1}->{n0} does not exist in the graph\."):
+        view.remove_edge_from_view(n1, n0)
+
+    # Edge id not in view
+    with pytest.raises(ValueError, match=r"Edge 999999 does not exist in the view\."):
+        view.remove_edge_from_view(edge_id=999999)
+
+    view.sync = False
+    with pytest.raises(RuntimeError, match=r"remove_edge_from_view requires sync=True"):
+        view.remove_edge_from_view(n0, n1)
+
+
 @parametrize_subgraph_tests
 def test_has_node(graph_backend: BaseGraph, use_subgraph: bool) -> None:
     """Test has_node functionality on both original graphs and subgraphs."""

--- a/src/tracksdata/graph/_test/test_subgraph.py
+++ b/src/tracksdata/graph/_test/test_subgraph.py
@@ -1302,6 +1302,170 @@ def test_remove_edge_from_view_validation(graph_backend: BaseGraph) -> None:
         view.remove_edge_from_view(n0, n1)
 
 
+def test_add_node_to_view_basic(graph_backend: BaseGraph) -> None:
+    """`add_node_to_view` re-surfaces a root node into the view without touching root."""
+    graph_backend.add_node_attr_key("x", pl.Float64)
+
+    n0 = graph_backend.add_node({"t": 0, "x": 0.0})
+    n1 = graph_backend.add_node({"t": 1, "x": 1.0})
+    n2 = graph_backend.add_node({"t": 2, "x": 2.0})
+
+    view = graph_backend.filter().subgraph()
+    assert isinstance(view, GraphView)
+
+    # Drop n1 from the view, then add it back.
+    view.remove_node_from_view(n1)
+    assert n1 not in view.node_ids()
+
+    view.add_node_to_view(n1)
+
+    # Back in the view, root never changed.
+    assert n1 in view.node_ids()
+    assert view.has_node(n1)
+    assert graph_backend.has_node(n1)
+    # Attribute value survives the round-trip (important for the copy-path backends).
+    df = view.node_attrs()
+    assert df.filter(pl.col(DEFAULT_ATTR_KEYS.NODE_ID) == n1)["x"].item() == 1.0
+    _ = (n0, n2)
+
+
+def test_add_node_to_view_roundtrip_identity(graph_backend: BaseGraph) -> None:
+    """remove + add restores the view's node/edge sets exactly (all backends)."""
+    graph_backend.add_node_attr_key("x", pl.Float64)
+    graph_backend.add_edge_attr_key("weight", pl.Float64)
+
+    n0 = graph_backend.add_node({"t": 0, "x": 0.0})
+    n1 = graph_backend.add_node({"t": 1, "x": 1.0})
+    n2 = graph_backend.add_node({"t": 2, "x": 2.0})
+    graph_backend.add_edge(n0, n1, {"weight": 0.2})
+    graph_backend.add_edge(n1, n2, {"weight": 0.8})
+
+    view = graph_backend.filter().subgraph()
+    nodes_before = set(view.node_ids())
+    edges_before = set(view._edge_map_to_root.values())
+
+    # Removing n1 also drops its two incident edges from the view.
+    view.remove_node_from_view(n1)
+    # Revive the node, then its incident edges.
+    view.add_node_to_view(n1)
+    view.add_edge_to_view(n0, n1)
+    view.add_edge_to_view(n1, n2)
+
+    assert set(view.node_ids()) == nodes_before
+    assert set(view._edge_map_to_root.values()) == edges_before
+    # Edge attributes survive the round-trip.
+    assert view.has_edge(n0, n1)
+    assert view.has_edge(n1, n2)
+    e_attrs = view.edge_attrs(attr_keys=["weight"])
+    weights = dict(
+        zip(
+            zip(e_attrs[DEFAULT_ATTR_KEYS.EDGE_SOURCE], e_attrs[DEFAULT_ATTR_KEYS.EDGE_TARGET], strict=False),
+            e_attrs["weight"],
+            strict=False,
+        )
+    )
+    assert weights[(n0, n1)] == 0.2
+    assert weights[(n1, n2)] == 0.8
+
+
+def test_add_node_to_view_signals(graph_backend: BaseGraph) -> None:
+    """Only the view's `node_added` fires; the root's signal does not."""
+    graph_backend.add_node_attr_key("x", pl.Float64)
+    n0 = graph_backend.add_node({"t": 0, "x": 0.0})
+    n1 = graph_backend.add_node({"t": 1, "x": 1.0})
+
+    view = graph_backend.filter().subgraph()
+    view.remove_node_from_view(n1)
+
+    view_calls: list[tuple[int, dict]] = []
+    root_calls: list[tuple[int, dict]] = []
+    view.node_added.connect(lambda nid, attrs: view_calls.append((nid, attrs)))
+    graph_backend.node_added.connect(lambda nid, attrs: root_calls.append((nid, attrs)))
+
+    view.add_node_to_view(n1)
+
+    assert len(root_calls) == 0
+    assert len(view_calls) == 1
+    assert view_calls[0][0] == n1
+    assert view_calls[0][1]["x"] == 1.0
+    _ = n0
+
+
+def test_add_node_to_view_validation(graph_backend: BaseGraph) -> None:
+    """Already-in-view / missing-in-root raise ValueError; sync=False raises RuntimeError."""
+    graph_backend.add_node_attr_key("x", pl.Float64)
+    n0 = graph_backend.add_node({"t": 0, "x": 0.0})
+
+    view = graph_backend.filter().subgraph()
+
+    # n0 is already in the view
+    with pytest.raises(ValueError, match=r"already in the view"):
+        view.add_node_to_view(n0)
+
+    # node that does not exist in the root
+    with pytest.raises(ValueError, match=r"does not exist in the root graph"):
+        view.add_node_to_view(999999)
+
+    view.remove_node_from_view(n0)
+    view.sync = False
+    with pytest.raises(RuntimeError, match=r"add_node_to_view requires sync=True"):
+        view.add_node_to_view(n0)
+
+
+def test_add_edge_to_view_basic(graph_backend: BaseGraph) -> None:
+    """`add_edge_to_view` re-surfaces a root edge into the view, leaving root untouched."""
+    graph_backend.add_node_attr_key("x", pl.Float64)
+    graph_backend.add_edge_attr_key("weight", pl.Float64)
+
+    n0 = graph_backend.add_node({"t": 0, "x": 0.0})
+    n1 = graph_backend.add_node({"t": 1, "x": 1.0})
+    graph_backend.add_edge(n0, n1, {"weight": 0.5})
+
+    view = graph_backend.filter().subgraph()
+    view.remove_edge_from_view(n0, n1)
+    assert not view.has_edge(n0, n1)
+
+    view.add_edge_to_view(n0, n1)
+    assert view.has_edge(n0, n1)
+    assert graph_backend.has_edge(n0, n1)
+    e_attrs = view.edge_attrs(attr_keys=["weight"])
+    row = e_attrs.filter((pl.col(DEFAULT_ATTR_KEYS.EDGE_SOURCE) == n0) & (pl.col(DEFAULT_ATTR_KEYS.EDGE_TARGET) == n1))
+    assert row["weight"].item() == 0.5
+
+
+def test_add_edge_to_view_validation(graph_backend: BaseGraph) -> None:
+    """Bad inputs raise ValueError; sync=False raises RuntimeError."""
+    graph_backend.add_node_attr_key("x", pl.Float64)
+    graph_backend.add_edge_attr_key("weight", pl.Float64)
+
+    n0 = graph_backend.add_node({"t": 0, "x": 0.0})
+    n1 = graph_backend.add_node({"t": 1, "x": 1.0})
+    n2 = graph_backend.add_node({"t": 2, "x": 2.0})
+    graph_backend.add_edge(n0, n1, {"weight": 0.5})
+
+    view = graph_backend.filter().subgraph()
+
+    # Endpoint not in the view
+    view.remove_node_from_view(n2)
+    with pytest.raises(ValueError, match=r"Endpoint .* is not in the view"):
+        view.add_edge_to_view(n0, n2)
+    view.add_node_to_view(n2)
+
+    # Root edge does not exist
+    with pytest.raises(ValueError, match=r"does not exist"):
+        view.add_edge_to_view(n1, n2)
+
+    # Edge already in the view
+    with pytest.raises(ValueError, match=r"already in the view"):
+        view.add_edge_to_view(n0, n1)
+
+    # sync=False
+    view.remove_edge_from_view(n0, n1)
+    view.sync = False
+    with pytest.raises(RuntimeError, match=r"add_edge_to_view requires sync=True"):
+        view.add_edge_to_view(n0, n1)
+
+
 @parametrize_subgraph_tests
 def test_has_node(graph_backend: BaseGraph, use_subgraph: bool) -> None:
     """Test has_node functionality on both original graphs and subgraphs."""


### PR DESCRIPTION
This PR adds helper functions to only 
- remove nodes/edges from the view (GraphView), not the `_root` graph. 
- add nodes/edges only to the view
- revive nodes into the view, that are present in the _root

Let's keep this PR open until I finalize things on the motile side, to see if everything works as desired