### PR TITLE
Batch operation refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,3 +198,4 @@ src/tracksdata/__about__.py
 
 # Claude
 .claude/
+.devcontainer/

--- a/src/tracksdata/array/_graph_array.py
+++ b/src/tracksdata/array/_graph_array.py
@@ -10,6 +10,7 @@ from tracksdata.constants import DEFAULT_ATTR_KEYS
 from tracksdata.graph._base_graph import BaseGraph
 from tracksdata.options import get_options
 from tracksdata.utils._dtypes import polars_dtype_to_numpy_dtype
+from tracksdata.utils._signal import iter_node_added_events, iter_node_updated_events
 
 if TYPE_CHECKING:
     from tracksdata.nodes._mask import Mask
@@ -415,15 +416,24 @@ class GraphArrayView(BaseReadOnlyArray):
         if slices is not None:
             self._cache.invalidate(time=time, volume_slicing=slices)
 
-    def _on_node_added(self, node_id: int, new_attrs: dict) -> None:
-        del node_id
-        self._invalidate_from_attrs(new_attrs)
+    def _on_node_added(
+        self,
+        node_id: int | Sequence[int],
+        new_attrs: dict | Sequence[dict],
+    ) -> None:
+        for _, attrs in iter_node_added_events(node_id, new_attrs):
+            self._invalidate_from_attrs(attrs)
 
     def _on_node_removed(self, node_id: int, old_attrs: dict) -> None:
         del node_id
         self._invalidate_from_attrs(old_attrs)
 
-    def _on_node_updated(self, node_id: int, old_attrs: dict, new_attrs: dict) -> None:
-        del node_id
-        self._invalidate_from_attrs(old_attrs)
-        self._invalidate_from_attrs(new_attrs)
+    def _on_node_updated(
+        self,
+        node_id: int | Sequence[int],
+        old_attrs: dict | Sequence[dict],
+        new_attrs: dict | Sequence[dict],
+    ) -> None:
+        for _, old_attr, new_attr in iter_node_updated_events(node_id, old_attrs, new_attrs):
+            self._invalidate_from_attrs(old_attr)
+            self._invalidate_from_attrs(new_attr)

--- a/src/tracksdata/array/_graph_array.py
+++ b/src/tracksdata/array/_graph_array.py
@@ -10,7 +10,6 @@ from tracksdata.constants import DEFAULT_ATTR_KEYS
 from tracksdata.graph._base_graph import BaseGraph
 from tracksdata.options import get_options
 from tracksdata.utils._dtypes import polars_dtype_to_numpy_dtype
-from tracksdata.utils._signal import iter_node_added_events, iter_node_updated_events
 
 if TYPE_CHECKING:
     from tracksdata.nodes._mask import Mask
@@ -418,22 +417,22 @@ class GraphArrayView(BaseReadOnlyArray):
 
     def _on_node_added(
         self,
-        node_id: int | Sequence[int],
-        new_attrs: dict | Sequence[dict],
+        node_ids: list[int],
+        new_attrs: list[dict],
     ) -> None:
-        for _, attrs in iter_node_added_events(node_id, new_attrs):
+        for attrs in new_attrs:
             self._invalidate_from_attrs(attrs)
 
-    def _on_node_removed(self, node_id: int, old_attrs: dict) -> None:
-        del node_id
-        self._invalidate_from_attrs(old_attrs)
+    def _on_node_removed(self, node_ids: list[int], old_attrs: list[dict]) -> None:
+        for attrs in old_attrs:
+            self._invalidate_from_attrs(attrs)
 
     def _on_node_updated(
         self,
-        node_id: int | Sequence[int],
-        old_attrs: dict | Sequence[dict],
-        new_attrs: dict | Sequence[dict],
+        node_ids: list[int],
+        old_attrs: list[dict],
+        new_attrs: list[dict],
     ) -> None:
-        for _, old_attr, new_attr in iter_node_updated_events(node_id, old_attrs, new_attrs):
+        for old_attr, new_attr in zip(old_attrs, new_attrs, strict=True):
             self._invalidate_from_attrs(old_attr)
             self._invalidate_from_attrs(new_attr)

--- a/src/tracksdata/graph/_base_graph.py
+++ b/src/tracksdata/graph/_base_graph.py
@@ -255,6 +255,38 @@ class BaseGraph(abc.ABC):
             If the node_id does not exist in the graph.
         """
 
+    def bulk_remove_nodes(self, node_ids: Sequence[int]) -> None:
+        """
+        Remove multiple nodes from the graph, along with their incident edges.
+
+        Existence is validated up-front so the call either removes every node
+        in `node_ids` or raises without modifying the graph.
+
+        Parameters
+        ----------
+        node_ids : Sequence[int]
+            The IDs of the nodes to remove.
+
+        Raises
+        ------
+        ValueError
+            If any node_id does not exist in the graph.
+        """
+        if hasattr(node_ids, "tolist"):
+            node_ids = node_ids.tolist()
+        else:
+            node_ids = list(node_ids)
+        if len(node_ids) == 0:
+            return
+
+        existing = set(self.node_ids())
+        missing = [nid for nid in node_ids if nid not in existing]
+        if missing:
+            raise ValueError(f"Node {missing[0]} does not exist in the graph.")
+
+        for node_id in node_ids:
+            self.remove_node(node_id)
+
     @abc.abstractmethod
     def add_edge(
         self,
@@ -313,6 +345,38 @@ class BaseGraph(abc.ABC):
         ValueError
             If the specified edge does not exist or insufficient identifiers are provided.
         """
+
+    def bulk_remove_edges(self, edge_ids: Sequence[int]) -> None:
+        """
+        Remove multiple edges from the graph by their edge IDs.
+
+        Existence is validated up-front so the call either removes every edge
+        in `edge_ids` or raises without modifying the graph.
+
+        Parameters
+        ----------
+        edge_ids : Sequence[int]
+            The IDs of the edges to remove.
+
+        Raises
+        ------
+        ValueError
+            If any edge_id does not exist in the graph.
+        """
+        if hasattr(edge_ids, "tolist"):
+            edge_ids = edge_ids.tolist()
+        else:
+            edge_ids = list(edge_ids)
+        if len(edge_ids) == 0:
+            return
+
+        existing = set(self.edge_ids())
+        missing = [eid for eid in edge_ids if eid not in existing]
+        if missing:
+            raise ValueError(f"Edge {missing[0]} does not exist in the graph.")
+
+        for edge_id in edge_ids:
+            self.remove_edge(edge_id=edge_id)
 
     @overload
     def bulk_add_edges(

--- a/src/tracksdata/graph/_base_graph.py
+++ b/src/tracksdata/graph/_base_graph.py
@@ -282,7 +282,6 @@ class BaseGraph(abc.ABC):
             If any node_id does not exist in the graph.
         """
 
-    @abc.abstractmethod
     def add_edge(
         self,
         source_id: int,
@@ -292,6 +291,10 @@ class BaseGraph(abc.ABC):
     ) -> int:
         """
         Add an edge to the graph.
+
+        Validates the attributes (when ``validate_keys`` is set) and then delegates
+        to :meth:`bulk_add_edges`; backends implement the bulk form and inherit this
+        single-edge wrapper.
 
         Parameters
         ----------
@@ -311,6 +314,17 @@ class BaseGraph(abc.ABC):
         int
             The ID of the added edge.
         """
+        if validate_keys:
+            self._validate_attributes(attrs, self.edge_attr_keys(), "edge")
+
+        # Normalise numpy scalar endpoints to native ints (required by the SQL backend).
+        if hasattr(source_id, "item"):
+            source_id = source_id.item()
+        if hasattr(target_id, "item"):
+            target_id = target_id.item()
+
+        edge = {DEFAULT_ATTR_KEYS.EDGE_SOURCE: source_id, DEFAULT_ATTR_KEYS.EDGE_TARGET: target_id, **attrs}
+        return self.bulk_add_edges([edge], return_ids=True)[0]
 
     @abc.abstractmethod
     def remove_edge(

--- a/src/tracksdata/graph/_base_graph.py
+++ b/src/tracksdata/graph/_base_graph.py
@@ -326,7 +326,6 @@ class BaseGraph(abc.ABC):
         edge = {DEFAULT_ATTR_KEYS.EDGE_SOURCE: source_id, DEFAULT_ATTR_KEYS.EDGE_TARGET: target_id, **attrs}
         return self.bulk_add_edges([edge], return_ids=True)[0]
 
-    @abc.abstractmethod
     def remove_edge(
         self,
         source_id: int | None = None,
@@ -339,6 +338,9 @@ class BaseGraph(abc.ABC):
 
         Either provide `edge_id` to remove by edge identifier, or
         provide both `source_id` and `target_id` to remove by endpoints.
+        Endpoint removal is resolved to an edge id via
+        [edge_id][tracksdata.graph.BaseGraph.edge_id]; the deletion itself is
+        delegated to [bulk_remove_edges][tracksdata.graph.BaseGraph.bulk_remove_edges].
 
         Parameters
         ----------
@@ -354,6 +356,11 @@ class BaseGraph(abc.ABC):
         ValueError
             If the specified edge does not exist or insufficient identifiers are provided.
         """
+        if edge_id is None:
+            if source_id is None or target_id is None:
+                raise ValueError("Provide either edge_id or both source_id and target_id.")
+            edge_id = self.edge_id(source_id, target_id)
+        self.bulk_remove_edges([edge_id])
 
     @abc.abstractmethod
     def bulk_remove_edges(self, edge_ids: Sequence[int]) -> None:

--- a/src/tracksdata/graph/_base_graph.py
+++ b/src/tracksdata/graph/_base_graph.py
@@ -162,7 +162,6 @@ class BaseGraph(abc.ABC):
                 f"{mode} attribute keys not found in attrs: '{missing_keys}'\nRequested keys: '{reference_keys}'"
             )
 
-    @abc.abstractmethod
     def add_node(
         self,
         attrs: dict[str, Any],
@@ -171,6 +170,10 @@ class BaseGraph(abc.ABC):
     ) -> int:
         """
         Add a node to the graph at time t.
+
+        Validates the attributes (when ``validate_keys`` is set) and then delegates
+        to :meth:`bulk_add_nodes`; backends implement the bulk form and inherit this
+        single-node wrapper.
 
         Parameters
         ----------
@@ -194,7 +197,15 @@ class BaseGraph(abc.ABC):
         int
             The ID of the added node.
         """
+        if validate_keys:
+            self._validate_attributes(attrs, self.node_attr_keys(), "node")
+            if "t" not in attrs:
+                raise ValueError(f"Node attributes must have a 't' key. Got {attrs.keys()}")
 
+        indices = None if index is None else [index]
+        return self.bulk_add_nodes([attrs], indices=indices)[0]
+
+    @abc.abstractmethod
     def bulk_add_nodes(
         self,
         nodes: list[dict[str, Any]],
@@ -202,6 +213,10 @@ class BaseGraph(abc.ABC):
     ) -> list[int]:
         """
         Faster method to add multiple nodes to the graph with less overhead and fewer checks.
+
+        Validation is intentionally skipped here; use :meth:`add_node` for the
+        validated single-node path. Implementations must accept an empty ``nodes``
+        list as a no-op.
 
         Parameters
         ----------
@@ -219,30 +234,20 @@ class BaseGraph(abc.ABC):
         list[int]
             The IDs of the added nodes.
         """
-        if len(nodes) == 0:
-            return []
-
-        self._validate_indices_length(nodes, indices)
-
-        # this method benefits the SQLGraph backend
-        if indices is None:
-            return [self.add_node(node, validate_keys=False) for node in nodes]
-        else:
-            return [
-                self.add_node(node, validate_keys=False, index=idx) for node, idx in zip(nodes, indices, strict=True)
-            ]
 
     def _validate_indices_length(self, nodes: list[dict[str, Any]], indices: list[int] | None) -> None:
         if indices is not None and len(indices) != len(nodes):
             raise ValueError(f"Length of indices ({len(indices)}) must match length of nodes ({len(nodes)})")
 
-    @abc.abstractmethod
     def remove_node(self, node_id: int) -> None:
         """
         Remove a node from the graph.
 
         This method removes the specified node and all edges connected to it
         (both incoming and outgoing edges).
+
+        Delegates to :meth:`bulk_remove_nodes`; backends implement the bulk form
+        and inherit this single-node wrapper.
 
         Parameters
         ----------
@@ -254,13 +259,17 @@ class BaseGraph(abc.ABC):
         ValueError
             If the node_id does not exist in the graph.
         """
+        self.bulk_remove_nodes([node_id])
 
+    @abc.abstractmethod
     def bulk_remove_nodes(self, node_ids: Sequence[int]) -> None:
         """
         Remove multiple nodes from the graph, along with their incident edges.
 
-        Existence is validated up-front so the call either removes every node
-        in `node_ids` or raises without modifying the graph.
+        Existence must be validated up-front so the call either removes every
+        node in `node_ids` or raises without modifying the graph. Implementations
+        must accept an empty `node_ids` as a no-op and normalise array-like inputs
+        (e.g. numpy arrays) to a list.
 
         Parameters
         ----------
@@ -272,20 +281,6 @@ class BaseGraph(abc.ABC):
         ValueError
             If any node_id does not exist in the graph.
         """
-        if hasattr(node_ids, "tolist"):
-            node_ids = node_ids.tolist()
-        else:
-            node_ids = list(node_ids)
-        if len(node_ids) == 0:
-            return
-
-        existing = set(self.node_ids())
-        missing = [nid for nid in node_ids if nid not in existing]
-        if missing:
-            raise ValueError(f"Node {missing[0]} does not exist in the graph.")
-
-        for node_id in node_ids:
-            self.remove_node(node_id)
 
     @abc.abstractmethod
     def add_edge(
@@ -346,12 +341,14 @@ class BaseGraph(abc.ABC):
             If the specified edge does not exist or insufficient identifiers are provided.
         """
 
+    @abc.abstractmethod
     def bulk_remove_edges(self, edge_ids: Sequence[int]) -> None:
         """
         Remove multiple edges from the graph by their edge IDs.
 
-        Existence is validated up-front so the call either removes every edge
-        in `edge_ids` or raises without modifying the graph.
+        Existence must be validated up-front so the call either removes every edge
+        in `edge_ids` or raises without modifying the graph. Implementations must
+        accept an empty `edge_ids` as a no-op and normalise array-like inputs to a list.
 
         Parameters
         ----------
@@ -363,20 +360,6 @@ class BaseGraph(abc.ABC):
         ValueError
             If any edge_id does not exist in the graph.
         """
-        if hasattr(edge_ids, "tolist"):
-            edge_ids = edge_ids.tolist()
-        else:
-            edge_ids = list(edge_ids)
-        if len(edge_ids) == 0:
-            return
-
-        existing = set(self.edge_ids())
-        missing = [eid for eid in edge_ids if eid not in existing]
-        if missing:
-            raise ValueError(f"Edge {missing[0]} does not exist in the graph.")
-
-        for edge_id in edge_ids:
-            self.remove_edge(edge_id=edge_id)
 
     @overload
     def bulk_add_edges(
@@ -392,6 +375,7 @@ class BaseGraph(abc.ABC):
         return_ids: Literal[True],
     ) -> list[int]: ...
 
+    @abc.abstractmethod
     def bulk_add_edges(
         self,
         edges: list[dict[str, Any]],
@@ -425,28 +409,6 @@ class BaseGraph(abc.ABC):
         list[int] | None
             The IDs of the added edges.
         """
-        # this method benefits the SQLGraph backend
-        if return_ids:
-            edge_ids = []
-            for edge in edges:
-                edge_ids.append(
-                    self.add_edge(
-                        edge.pop(DEFAULT_ATTR_KEYS.EDGE_SOURCE),
-                        edge.pop(DEFAULT_ATTR_KEYS.EDGE_TARGET),
-                        edge,
-                        validate_keys=False,
-                    )
-                )
-            return edge_ids
-
-        # avoiding many ifs and appends
-        for edge in edges:
-            self.add_edge(
-                edge.pop(DEFAULT_ATTR_KEYS.EDGE_SOURCE),
-                edge.pop(DEFAULT_ATTR_KEYS.EDGE_TARGET),
-                edge,
-                validate_keys=False,
-            )
 
     def add_overlap(
         self,

--- a/src/tracksdata/graph/_base_graph.py
+++ b/src/tracksdata/graph/_base_graph.py
@@ -110,9 +110,9 @@ class BaseGraph(abc.ABC):
     """
 
     _PRIVATE_METADATA_PREFIX = "__private_"
-    node_added = Signal(int, dict)
-    node_removed = Signal(int, dict)
-    node_updated = Signal(int, dict, dict)
+    node_added = Signal(list, list)
+    node_removed = Signal(list, list)
+    node_updated = Signal(list, list, list)
 
     def __init__(self) -> None:
         self._cache = {}

--- a/src/tracksdata/graph/_graph_view.py
+++ b/src/tracksdata/graph/_graph_view.py
@@ -12,7 +12,11 @@ from tracksdata.graph._mapped_graph_mixin import MappedGraphMixin
 from tracksdata.graph._rustworkx_graph import IndexedRXGraph, RustWorkXGraph, RXFilter
 from tracksdata.graph.filters._indexed_filter import IndexRXFilter
 from tracksdata.utils._dtypes import AttrSchema
-from tracksdata.utils._signal import is_signal_on
+from tracksdata.utils._signal import (
+    emit_node_added_events,
+    emit_node_updated_events,
+    is_signal_on,
+)
 
 
 class GraphView(MappedGraphMixin, RustWorkXGraph):
@@ -390,12 +394,8 @@ class GraphView(MappedGraphMixin, RustWorkXGraph):
             )
 
         if self.sync:
-            with self.node_added.blocked():
-                node_id = RustWorkXGraph.add_node(
-                    self,
-                    attrs=attrs,
-                    validate_keys=validate_keys,
-                )
+            # Local primitive: pure rx_graph + _time_to_nodes, no validation, no signal.
+            node_id = self._bulk_add_nodes_local([attrs])[0]
             self._add_id_mapping(node_id, parent_node_id)
         else:
             self._out_of_sync = True
@@ -411,20 +411,20 @@ class GraphView(MappedGraphMixin, RustWorkXGraph):
         with self._root.node_added.blocked():
             parent_node_ids = self._root.bulk_add_nodes(nodes, indices=indices)
 
+        # Defensive: drop NODE_ID from emitted/local-stored attrs in case the root
+        # backend (e.g. older SQL paths) injected it.
+        emitted_nodes = [
+            {key: value for key, value in node_attrs.items() if key != DEFAULT_ATTR_KEYS.NODE_ID}
+            for node_attrs in nodes
+        ]
         if self.sync:
-            with self.node_added.blocked():
-                node_ids = RustWorkXGraph.bulk_add_nodes(self, nodes)
+            node_ids = self._bulk_add_nodes_local(emitted_nodes)
             self._add_id_mappings(list(zip(node_ids, parent_node_ids, strict=True)))
         else:
             self._out_of_sync = True
 
-        if is_signal_on(self._root.node_added):
-            for node_id, node_attrs in zip(parent_node_ids, nodes, strict=True):
-                self._root.node_added.emit(node_id, node_attrs)
-
-        if is_signal_on(self.node_added):
-            for node_id, node_attrs in zip(parent_node_ids, nodes, strict=True):
-                self.node_added.emit(node_id, node_attrs)
+        emit_node_added_events(self._root.node_added, zip(parent_node_ids, emitted_nodes, strict=True))
+        emit_node_added_events(self.node_added, zip(parent_node_ids, emitted_nodes, strict=True))
 
         return parent_node_ids
 
@@ -462,11 +462,9 @@ class GraphView(MappedGraphMixin, RustWorkXGraph):
             self._root.remove_node(node_id)
 
         if self.sync:
-            # Get the local node ID and remove from local graph
+            # Local primitive: pure rx_graph + _time_to_nodes, no signal.
             local_node_id = self._external_to_local[node_id]
-
-            with self.node_removed.blocked():
-                super().remove_node(local_node_id)
+            self._bulk_remove_nodes_local([local_node_id])
 
             # Remove the node mapping
             self._remove_id_mapping(external_id=node_id)
@@ -489,6 +487,61 @@ class GraphView(MappedGraphMixin, RustWorkXGraph):
             self._root.node_removed.emit(node_id, old_attrs)
         if view_signal_on:
             self.node_removed.emit(node_id, old_attrs)
+
+    def bulk_remove_nodes(self, node_ids: Sequence[int]) -> None:
+        """
+        Remove multiple nodes from both the view and the root graph.
+
+        Parameters
+        ----------
+        node_ids : Sequence[int]
+            External IDs of the nodes to remove.
+
+        Raises
+        ------
+        ValueError
+            If any node_id does not exist in the graph.
+        """
+        if hasattr(node_ids, "tolist"):
+            node_ids = node_ids.tolist()
+        else:
+            node_ids = list(node_ids)
+        if len(node_ids) == 0:
+            return
+
+        missing = [nid for nid in node_ids if nid not in self._external_to_local]
+        if missing:
+            raise ValueError(f"Node {missing[0]} does not exist in the graph.")
+
+        view_signal_on = is_signal_on(self.node_removed)
+        root_signal_on = is_signal_on(self._root.node_removed)
+        old_attrs_per_node: dict[int, dict[str, Any]] = {}
+        if view_signal_on or root_signal_on:
+            for nid in node_ids:
+                old_attrs_per_node[nid] = self.nodes[nid].to_dict()
+
+        with self._root.node_removed.blocked():
+            self._root.bulk_remove_nodes(node_ids)
+
+        if self.sync:
+            local_ids = [self._external_to_local[nid] for nid in node_ids]
+            self._bulk_remove_nodes_local(local_ids)
+            for nid in node_ids:
+                self._remove_id_mapping(external_id=nid)
+
+            edge_indices = set(self.rx_graph.edge_indices())
+            for local_edge_id in list(self._edge_map_to_root.keys()):
+                if local_edge_id not in edge_indices:
+                    del self._edge_map_to_root[local_edge_id]
+        else:
+            self._out_of_sync = True
+
+        if root_signal_on:
+            for nid in node_ids:
+                self._root.node_removed.emit(nid, old_attrs_per_node[nid])
+        if view_signal_on:
+            for nid in node_ids:
+                self.node_removed.emit(nid, old_attrs_per_node[nid])
 
     def add_edge(
         self,
@@ -573,6 +626,40 @@ class GraphView(MappedGraphMixin, RustWorkXGraph):
                 src, tgt, _ = edge_map[local_edge_id]
                 self.rx_graph.remove_edge(src, tgt)
                 del self._edge_map_to_root[local_edge_id]
+        else:
+            self._out_of_sync = True
+
+    def bulk_remove_edges(self, edge_ids: Sequence[int]) -> None:
+        """
+        Remove multiple edges from both the root and (if present) the view.
+
+        Parameters
+        ----------
+        edge_ids : Sequence[int]
+            Root edge IDs to remove.
+
+        Raises
+        ------
+        ValueError
+            If any edge_id does not exist in the root graph.
+        """
+        if hasattr(edge_ids, "tolist"):
+            edge_ids = edge_ids.tolist()
+        else:
+            edge_ids = list(edge_ids)
+        if len(edge_ids) == 0:
+            return
+
+        self._root.bulk_remove_edges(edge_ids)
+
+        if self.sync:
+            edge_map = self.rx_graph.edge_index_map()
+            for root_eid in edge_ids:
+                if root_eid in self._edge_map_from_root:
+                    local_edge_id = self._edge_map_from_root[root_eid]
+                    src, tgt, _ = edge_map[local_edge_id]
+                    self.rx_graph.remove_edge(src, tgt)
+                    del self._edge_map_to_root[local_edge_id]
         else:
             self._out_of_sync = True
 
@@ -747,19 +834,15 @@ class GraphView(MappedGraphMixin, RustWorkXGraph):
             )
             old_attrs_by_id = cast(dict[int, dict[str, Any]], old_attrs_by_id)  # for mypy
             if root_signal_on:
-                for node_id in node_ids:
-                    self._root.node_updated.emit(
-                        node_id,
-                        old_attrs_by_id[node_id],
-                        new_attrs_by_id[node_id],
-                    )
+                emit_node_updated_events(
+                    self._root.node_updated,
+                    ((node_id, old_attrs_by_id[node_id], new_attrs_by_id[node_id]) for node_id in node_ids),
+                )
             if view_signal_on:
-                for node_id in node_ids:
-                    self.node_updated.emit(
-                        node_id,
-                        old_attrs_by_id[node_id],
-                        new_attrs_by_id[node_id],
-                    )
+                emit_node_updated_events(
+                    self.node_updated,
+                    ((node_id, old_attrs_by_id[node_id], new_attrs_by_id[node_id]) for node_id in node_ids),
+                )
 
     def update_edge_attrs(
         self,

--- a/src/tracksdata/graph/_graph_view.py
+++ b/src/tracksdata/graph/_graph_view.py
@@ -401,10 +401,8 @@ class GraphView(MappedGraphMixin, RustWorkXGraph):
         else:
             self._out_of_sync = True
 
-        if is_signal_on(self._root.node_added):
-            self._root.node_added.emit(parent_node_id, attrs)
-        if is_signal_on(self.node_added):
-            self.node_added.emit(parent_node_id, attrs)
+        emit_node_added_events(self._root.node_added, [(parent_node_id, attrs)])
+        emit_node_added_events(self.node_added, [(parent_node_id, attrs)])
 
         return parent_node_id
 

--- a/src/tracksdata/graph/_graph_view.py
+++ b/src/tracksdata/graph/_graph_view.py
@@ -517,8 +517,14 @@ class GraphView(MappedGraphMixin, RustWorkXGraph):
         root_signal_on = is_signal_on(self._root.node_removed)
         old_attrs_per_node: dict[int, dict[str, Any]] = {}
         if view_signal_on or root_signal_on:
-            for nid in node_ids:
-                old_attrs_per_node[nid] = self.nodes[nid].to_dict()
+            # Single batched query instead of one filter+materialize per node.
+            # include_key defaults to False, so NODE_ID is excluded from each attrs
+            # dict, matching the previous per-node NodeInterface.to_dict() behaviour.
+            old_attrs_per_node = (
+                self.filter(node_ids=node_ids)
+                .node_attrs()
+                .rows_by_key(key=DEFAULT_ATTR_KEYS.NODE_ID, named=True, unique=True)
+            )
 
         with self._root.node_removed.blocked():
             self._root.bulk_remove_nodes(node_ids)

--- a/src/tracksdata/graph/_graph_view.py
+++ b/src/tracksdata/graph/_graph_view.py
@@ -429,66 +429,6 @@ class GraphView(MappedGraphMixin, RustWorkXGraph):
 
         return parent_node_ids
 
-    def remove_node(self, node_id: int) -> None:
-        """
-        Remove a node from the graph.
-
-        This method removes the node from both the view and the root graph,
-        along with all connected edges. Also updates the node mappings.
-
-        Parameters
-        ----------
-        node_id : int
-            The ID of the node to remove.
-
-        Raises
-        ------
-        ValueError
-            If the node_id does not exist in the graph.
-        """
-        if node_id not in self._external_to_local:
-            raise ValueError(f"Node {node_id} does not exist in the graph.")
-
-        # Capture signal state once so a slot connecting mid-call cannot reference
-        # an unbound `old_attrs`.
-        view_signal_on = is_signal_on(self.node_removed)
-        root_signal_on = is_signal_on(self._root.node_removed)
-        if view_signal_on or root_signal_on:
-            old_attrs = self.nodes[node_id].to_dict()
-
-        # Remove from root graph first, because removing bounding box requires node attrs.
-        # Block root's signal so it doesn't fire while the view is still in old state;
-        # re-emit at the end after both root and view are consistent.
-        with self._root.node_removed.blocked():
-            self._root.remove_node(node_id)
-
-        if self.sync:
-            # Local primitive: pure rx_graph + _time_to_nodes, no signal.
-            local_node_id = self._external_to_local[node_id]
-            self._bulk_remove_nodes_local([local_node_id])
-
-            # Remove the node mapping
-            self._remove_id_mapping(external_id=node_id)
-
-            # Update edge mappings - remove edges involving this node
-            edges_to_remove = []
-            edge_indices = self.rx_graph.edge_indices()
-            for local_edge_id, _ in list(self._edge_map_to_root.items()):
-                # Check if this edge is still in the local graph
-                if local_edge_id not in edge_indices:
-                    edges_to_remove.append(local_edge_id)
-
-            for edge_id in edges_to_remove:
-                if edge_id in self._edge_map_to_root:
-                    del self._edge_map_to_root[edge_id]
-        else:
-            self._out_of_sync = True
-
-        if root_signal_on:
-            self._root.node_removed.emit(node_id, old_attrs)
-        if view_signal_on:
-            self.node_removed.emit(node_id, old_attrs)
-
     def bulk_remove_nodes(self, node_ids: Sequence[int]) -> None:
         """
         Remove multiple nodes from both the view and the root graph.

--- a/src/tracksdata/graph/_graph_view.py
+++ b/src/tracksdata/graph/_graph_view.py
@@ -14,6 +14,7 @@ from tracksdata.graph.filters._indexed_filter import IndexRXFilter
 from tracksdata.utils._dtypes import AttrSchema
 from tracksdata.utils._signal import (
     emit_node_added_events,
+    emit_node_removed_events,
     emit_node_updated_events,
     is_signal_on,
 )
@@ -543,11 +544,9 @@ class GraphView(MappedGraphMixin, RustWorkXGraph):
             self._out_of_sync = True
 
         if root_signal_on:
-            for nid in node_ids:
-                self._root.node_removed.emit(nid, old_attrs_per_node[nid])
+            emit_node_removed_events(self._root.node_removed, ((nid, old_attrs_per_node[nid]) for nid in node_ids))
         if view_signal_on:
-            for nid in node_ids:
-                self.node_removed.emit(nid, old_attrs_per_node[nid])
+            emit_node_removed_events(self.node_removed, ((nid, old_attrs_per_node[nid]) for nid in node_ids))
 
     def add_edge(
         self,

--- a/src/tracksdata/graph/_graph_view.py
+++ b/src/tracksdata/graph/_graph_view.py
@@ -542,38 +542,6 @@ class GraphView(MappedGraphMixin, RustWorkXGraph):
         if return_ids:
             return parent_edge_ids
 
-    def remove_edge(
-        self,
-        source_id: int | None = None,
-        target_id: int | None = None,
-        *,
-        edge_id: int | None = None,
-    ) -> None:
-        """
-        Remove an edge by ID or by endpoints in both the root and (if present) the view.
-        """
-        # Remove from root first
-        if edge_id is None:
-            if source_id is None or target_id is None:
-                raise ValueError("Provide either edge_id or both source_id and target_id.")
-            try:
-                edge_id = self._root.edge_id(source_id, target_id)
-            # Ensure the same error raised by the SQLGraph
-            except rx.NoEdgeBetweenNodes as e:
-                raise ValueError(f"Edge {source_id}->{target_id} does not exist in the graph.") from e
-        self._root.remove_edge(edge_id=edge_id)  # Error raised from root if edge_id not found
-
-        # Remove from the local graph if synced
-        if self.sync:
-            if edge_id in self._edge_map_from_root:
-                local_edge_id = self._edge_map_from_root[edge_id]
-                edge_map = self.rx_graph.edge_index_map()
-                src, tgt, _ = edge_map[local_edge_id]
-                self.rx_graph.remove_edge(src, tgt)
-                del self._edge_map_to_root[local_edge_id]
-        else:
-            self._out_of_sync = True
-
     def bulk_remove_edges(self, edge_ids: Sequence[int]) -> None:
         """
         Remove multiple edges from both the root and (if present) the view.

--- a/src/tracksdata/graph/_mapped_graph_mixin.py
+++ b/src/tracksdata/graph/_mapped_graph_mixin.py
@@ -202,7 +202,11 @@ class MappedGraphMixin:
         mappings : Sequence[tuple[int, int]]
             Sequence of (local_id, external_id) pairs
         """
-        self._local_to_external.putall(mappings)
+        try:
+            self._local_to_external.putall(mappings)
+        except bidict.ValueDuplicationError as e:
+            # Match the single-add path: an external_id collision is the user-facing "key" duplication.
+            raise bidict.KeyDuplicationError(e.args[0]) from e
 
     def _remove_id_mapping(
         self,

--- a/src/tracksdata/graph/_rustworkx_graph.py
+++ b/src/tracksdata/graph/_rustworkx_graph.py
@@ -16,7 +16,11 @@ from tracksdata.utils._cache import cache_method
 from tracksdata.utils._dataframe import unpack_array_attrs
 from tracksdata.utils._dtypes import AttrSchema, process_attr_key_args
 from tracksdata.utils._logging import LOG
-from tracksdata.utils._signal import is_signal_on
+from tracksdata.utils._signal import (
+    emit_node_added_events,
+    emit_node_updated_events,
+    is_signal_on,
+)
 
 if TYPE_CHECKING:
     from tracksdata.graph._graph_view import GraphView
@@ -472,6 +476,88 @@ class RustWorkXGraph(BaseGraph):
             include_sources=include_sources,
         )
 
+    # ------------------------------------------------------------------
+    # Local primitives — pure rx_graph mutation + bookkeeping.
+    # No validation, no signal emission, no policy. Subclasses must NOT
+    # override these; override the public methods (or their bulk forms)
+    # instead. Callers that want to bypass virtual dispatch on the public
+    # methods (e.g. GraphView routing its local layer) call these.
+    # ------------------------------------------------------------------
+
+    def _bulk_add_nodes_local(self, nodes: list[dict[str, Any]]) -> list[int]:
+        """Append `nodes` to rx_graph and update _time_to_nodes. Returns new local ids."""
+        node_indices = list(self.rx_graph.add_nodes_from(nodes))
+        for node, idx in zip(nodes, node_indices, strict=True):
+            self._time_to_nodes.setdefault(node["t"], []).append(idx)
+        return node_indices
+
+    def _bulk_remove_nodes_local(
+        self,
+        node_ids: list[int],
+        *,
+        capture_attrs: bool = False,
+    ) -> dict[int, dict[str, Any]]:
+        """
+        Remove `node_ids` from rx_graph, refresh _time_to_nodes and _overlaps.
+
+        Raises ValueError before any mutation if any id is missing.
+        Returns a {node_id: attrs} snapshot iff `capture_attrs` is True (else `{}`),
+        so callers that need to emit signals can do so without re-querying.
+        """
+        rx_indices = set(self.rx_graph.node_indices())
+        missing = [nid for nid in node_ids if nid not in rx_indices]
+        if missing:
+            raise ValueError(f"Node {missing[0]} does not exist in the graph.")
+
+        old_attrs_per_node = {nid: dict(self.rx_graph[nid]) for nid in node_ids} if capture_attrs else {}
+        times_per_node = [(nid, self.rx_graph[nid]["t"]) for nid in node_ids]
+
+        self.rx_graph.remove_nodes_from(node_ids)
+
+        by_time: dict[Any, set[int]] = {}
+        for nid, t in times_per_node:
+            by_time.setdefault(t, set()).add(nid)
+        for t, removed in by_time.items():
+            remaining = [n for n in self._time_to_nodes[t] if n not in removed]
+            if remaining:
+                self._time_to_nodes[t] = remaining
+            else:
+                del self._time_to_nodes[t]
+
+        if self._overlaps is not None:
+            nid_set = set(node_ids)
+            self._overlaps = [o for o in self._overlaps if o[0] not in nid_set and o[1] not in nid_set]
+
+        return old_attrs_per_node
+
+    def _add_edge_local(self, source_id: int, target_id: int, attrs: dict[str, Any]) -> int:
+        """Add a single edge to rx_graph and stamp EDGE_ID into `attrs`. Returns the edge id."""
+        edge_id = self.rx_graph.add_edge(source_id, target_id, attrs)
+        attrs[DEFAULT_ATTR_KEYS.EDGE_ID] = edge_id
+        return edge_id
+
+    def _bulk_add_edges_local(self, edges: list[dict[str, Any]]) -> list[int]:
+        """Loop _add_edge_local over `edges` (pops source/target from each dict)."""
+        edge_ids: list[int] = []
+        for edge in edges:
+            src = edge.pop(DEFAULT_ATTR_KEYS.EDGE_SOURCE)
+            tgt = edge.pop(DEFAULT_ATTR_KEYS.EDGE_TARGET)
+            edge_ids.append(self._add_edge_local(src, tgt, edge))
+        return edge_ids
+
+    def _bulk_remove_edges_local(self, edge_ids: list[int]) -> None:
+        """Atomic-validate then drop edges by id via rx_graph.remove_edges_from."""
+        edge_map = self.rx_graph.edge_index_map()
+        missing = [eid for eid in edge_ids if eid not in edge_map]
+        if missing:
+            raise ValueError(f"Edge {missing[0]} does not exist in the graph.")
+        endpoints = [(edge_map[eid][0], edge_map[eid][1]) for eid in edge_ids]
+        self.rx_graph.remove_edges_from(endpoints)
+
+    # ------------------------------------------------------------------
+    # Public mutation API — validation + signals on top of the locals.
+    # ------------------------------------------------------------------
+
     def add_node(
         self,
         attrs: dict[str, Any],
@@ -501,15 +587,12 @@ class RustWorkXGraph(BaseGraph):
         if index is not None:
             raise ValueError("RustWorkXGraph does not support custom node indices. Use IndexedRXGraph instead.")
 
-        # avoiding copying attributes on purpose, it could be a problem in the future
         if validate_keys:
             self._validate_attributes(attrs, self.node_attr_keys(), "node")
-
             if "t" not in attrs:
                 raise ValueError(f"Node attributes must have a 't' key. Got {attrs.keys()}")
 
-        node_id = self.rx_graph.add_node(attrs)
-        self._time_to_nodes.setdefault(attrs["t"], []).append(node_id)
+        node_id = self._bulk_add_nodes_local([attrs])[0]
         if is_signal_on(self.node_added):
             self.node_added.emit(node_id, attrs)
         return node_id
@@ -536,15 +619,8 @@ class RustWorkXGraph(BaseGraph):
         if indices is not None:
             raise ValueError("RustWorkXGraph does not support custom node indices. Use IndexedRXGraph instead.")
 
-        node_indices = list(self.rx_graph.add_nodes_from(nodes))
-        for node, index in zip(nodes, node_indices, strict=True):
-            self._time_to_nodes.setdefault(node["t"], []).append(index)
-
-        # checking if it has connections to reduce overhead
-        if is_signal_on(self.node_added):
-            for node_id, node_attrs in zip(node_indices, nodes, strict=True):
-                self.node_added.emit(node_id, node_attrs)
-
+        node_indices = self._bulk_add_nodes_local(nodes)
+        emit_node_added_events(self.node_added, zip(node_indices, nodes, strict=True))
         return node_indices
 
     def remove_node(self, node_id: int) -> None:
@@ -564,31 +640,37 @@ class RustWorkXGraph(BaseGraph):
         ValueError
             If the node_id does not exist in the graph.
         """
-        if node_id not in self.rx_graph.node_indices():
-            raise ValueError(f"Node {node_id} does not exist in the graph.")
+        emit = is_signal_on(self.node_removed)
+        captured = self._bulk_remove_nodes_local([node_id], capture_attrs=emit)
+        if emit:
+            self.node_removed.emit(node_id, captured[node_id])
 
-        old_attrs = None
-        if is_signal_on(self.node_removed):
-            old_attrs = dict(self.rx_graph[node_id])
+    def bulk_remove_nodes(self, node_ids: Sequence[int]) -> None:
+        """
+        Remove multiple nodes from the graph, along with their incident edges and overlaps.
 
-        # Get the time value before removing the node
-        t = self.rx_graph[node_id]["t"]
+        Parameters
+        ----------
+        node_ids : Sequence[int]
+            The IDs of the nodes to remove.
 
-        # Remove the node from the graph (this also removes all connected edges)
-        self.rx_graph.remove_node(node_id)
+        Raises
+        ------
+        ValueError
+            If any node_id does not exist in the graph.
+        """
+        if hasattr(node_ids, "tolist"):
+            node_ids = node_ids.tolist()
+        else:
+            node_ids = list(node_ids)
+        if len(node_ids) == 0:
+            return
 
-        # Update the time_to_nodes mapping
-        self._time_to_nodes[t].remove(node_id)
-        # Clean up empty time entries
-        if not self._time_to_nodes[t]:
-            del self._time_to_nodes[t]
-
-        # Remove from overlaps if present
-        if self._overlaps is not None:
-            self._overlaps = [overlap for overlap in self._overlaps if node_id != overlap[0] and node_id != overlap[1]]
-
-        if is_signal_on(self.node_removed):
-            self.node_removed.emit(node_id, old_attrs)
+        emit = is_signal_on(self.node_removed)
+        captured = self._bulk_remove_nodes_local(node_ids, capture_attrs=emit)
+        if emit:
+            for nid in node_ids:
+                self.node_removed.emit(nid, captured[nid])
 
     def add_edge(
         self,
@@ -616,9 +698,7 @@ class RustWorkXGraph(BaseGraph):
         """
         if validate_keys:
             self._validate_attributes(attrs, self.edge_attr_keys(), "edge")
-        edge_id = self.rx_graph.add_edge(source_id, target_id, attrs)
-        attrs[DEFAULT_ATTR_KEYS.EDGE_ID] = edge_id
-        return edge_id
+        return self._add_edge_local(source_id, target_id, attrs)
 
     def bulk_add_edges(self, edges: list[dict[str, Any]], return_ids: bool = False) -> list[int] | None:
         """
@@ -649,13 +729,9 @@ class RustWorkXGraph(BaseGraph):
         list[int] | None
             The IDs of the added edges.
         """
-        # saving for historical reasons, iterating over edges is faster than using rx.add_edges_from
-        # edges_data = [(d.pop(DEFAULT_ATTR_KEYS.EDGE_SOURCE), d.pop(DEFAULT_ATTR_KEYS.EDGE_TARGET), d) for d in edges]
-        # indices = self.rx_graph.add_edges_from(edges_data)
-        # for i, d in zip(indices, edges, strict=True):
-        #     d[DEFAULT_ATTR_KEYS.EDGE_ID] = i
-        # return indices
-        return super().bulk_add_edges(edges, return_ids=return_ids)
+        # Per-edge loop is faster than rx.add_edges_from in practice; the local primitive iterates.
+        edge_ids = self._bulk_add_edges_local(edges)
+        return edge_ids if return_ids else None
 
     def remove_edge(
         self,
@@ -667,19 +743,38 @@ class RustWorkXGraph(BaseGraph):
         """
         Remove an edge by ID or by endpoints.
         """
-        if edge_id is None:
-            if source_id is None or target_id is None:
-                raise ValueError("Provide either edge_id or both source_id and target_id.")
-            try:
-                self.rx_graph.remove_edge(source_id, target_id)
-            except rx.NoEdgeBetweenNodes as e:
-                raise ValueError(f"Edge {source_id}->{target_id} does not exist in the graph.") from e
+        if edge_id is not None:
+            self._bulk_remove_edges_local([edge_id])
+            return
+
+        if source_id is None or target_id is None:
+            raise ValueError("Provide either edge_id or both source_id and target_id.")
+        try:
+            self.rx_graph.remove_edge(source_id, target_id)
+        except rx.NoEdgeBetweenNodes as e:
+            raise ValueError(f"Edge {source_id}->{target_id} does not exist in the graph.") from e
+
+    def bulk_remove_edges(self, edge_ids: Sequence[int]) -> None:
+        """
+        Remove multiple edges from the graph by their edge IDs.
+
+        Parameters
+        ----------
+        edge_ids : Sequence[int]
+            The IDs of the edges to remove.
+
+        Raises
+        ------
+        ValueError
+            If any edge_id does not exist in the graph.
+        """
+        if hasattr(edge_ids, "tolist"):
+            edge_ids = edge_ids.tolist()
         else:
-            edge_map = self.rx_graph.edge_index_map()
-            if edge_id not in edge_map:
-                raise ValueError(f"Edge {edge_id} does not exist in the graph.")
-            src, tgt, _ = edge_map[edge_id]
-            self.rx_graph.remove_edge(src, tgt)
+            edge_ids = list(edge_ids)
+        if len(edge_ids) == 0:
+            return
+        self._bulk_remove_edges_local(edge_ids)
 
     def add_overlap(
         self,
@@ -1228,6 +1323,8 @@ class RustWorkXGraph(BaseGraph):
         """
         if node_ids is None:
             node_ids = self.node_ids()
+        else:
+            node_ids = list(node_ids)
 
         if is_signal_on(self.node_updated):
             old_attrs_by_id = {node_id: dict(self._graph[node_id]) for node_id in node_ids}
@@ -1247,8 +1344,10 @@ class RustWorkXGraph(BaseGraph):
                 self._graph[node_id][key] = v
 
         if is_signal_on(self.node_updated):
-            for node_id in node_ids:
-                self.node_updated.emit(node_id, old_attrs_by_id[node_id], dict(self._graph[node_id]))
+            emit_node_updated_events(
+                self.node_updated,
+                ((node_id, old_attrs_by_id[node_id], dict(self._graph[node_id])) for node_id in node_ids),
+            )
 
     def update_edge_attrs(
         self,
@@ -1632,19 +1731,14 @@ class IndexedRXGraph(MappedGraphMixin, RustWorkXGraph):
         int
             The index of the node.
         """
-        with self.node_added.blocked():
-            node_id = super().add_node(attrs, validate_keys)
+        if validate_keys:
+            self._validate_attributes(attrs, self.node_attr_keys(), "node")
 
-        if index is None:
-            index = self._get_next_available_external_id()
-        else:
-            # Update counter if explicit index is higher to avoid future collisions
-            self._next_external_id = max(self._next_external_id, index + 1)
-        # Add mapping using mixin
-        self._add_id_mapping(node_id, index)
-        if is_signal_on(self.node_added):
-            self.node_added.emit(index, attrs)
-        return index
+            if "t" not in attrs:
+                raise ValueError(f"Node attributes must have a 't' key. Got {attrs.keys()}")
+
+        indices = None if index is None else [index]
+        return self.bulk_add_nodes([attrs], indices=indices)[0]
 
     def bulk_add_nodes(
         self,
@@ -1672,8 +1766,8 @@ class IndexedRXGraph(MappedGraphMixin, RustWorkXGraph):
 
         self._validate_indices_length(nodes, indices)
 
-        with self.node_added.blocked():
-            graph_ids = super().bulk_add_nodes(nodes)
+        # Local primitive: no signal emission, so no blocked() wrapper needed.
+        graph_ids = self._bulk_add_nodes_local(nodes)
 
         if indices is None:
             # All nodes get auto-generated indices
@@ -1688,9 +1782,7 @@ class IndexedRXGraph(MappedGraphMixin, RustWorkXGraph):
 
         self._add_id_mappings(list(zip(graph_ids, indices, strict=True)))
 
-        if is_signal_on(self.node_added):
-            for index, node_attrs in zip(indices, nodes, strict=True):
-                self.node_added.emit(index, node_attrs)
+        emit_node_added_events(self.node_added, zip(indices, nodes, strict=True))
 
         return indices
 
@@ -1862,6 +1954,22 @@ class IndexedRXGraph(MappedGraphMixin, RustWorkXGraph):
         target_id = self._map_to_local(target_id)
         return super().add_edge(source_id, target_id, attrs, validate_keys)
 
+    def bulk_add_edges(
+        self,
+        edges: list[dict[str, Any]],
+        return_ids: bool = False,
+    ) -> list[int] | None:
+        """
+        Map each edge's external endpoints to local rx ids, then delegate.
+
+        Mutates `edges` in place — same convention as the parent class, which
+        pops `source_id` / `target_id` from each dict before insert.
+        """
+        for edge in edges:
+            edge[DEFAULT_ATTR_KEYS.EDGE_SOURCE] = self._map_to_local(edge[DEFAULT_ATTR_KEYS.EDGE_SOURCE])
+            edge[DEFAULT_ATTR_KEYS.EDGE_TARGET] = self._map_to_local(edge[DEFAULT_ATTR_KEYS.EDGE_TARGET])
+        return super().bulk_add_edges(edges, return_ids=return_ids)
+
     def remove_edge(
         self,
         source_id: int | None = None,
@@ -1987,12 +2095,13 @@ class IndexedRXGraph(MappedGraphMixin, RustWorkXGraph):
             super().update_node_attrs(attrs=attrs, node_ids=local_node_ids)
 
         if is_signal_on(self.node_updated) and old_attrs_by_id is not None:
-            for external_node_id, local_node_id in zip(external_node_ids, local_node_ids, strict=True):
-                self.node_updated.emit(
-                    external_node_id,
-                    old_attrs_by_id[external_node_id],
-                    dict(self._graph[local_node_id]),
-                )
+            emit_node_updated_events(
+                self.node_updated,
+                (
+                    (external_node_id, old_attrs_by_id[external_node_id], dict(self._graph[local_node_id]))
+                    for external_node_id, local_node_id in zip(external_node_ids, local_node_ids, strict=True)
+                ),
+            )
 
     def remove_node(self, node_id: int) -> None:
         """
@@ -2008,21 +2117,49 @@ class IndexedRXGraph(MappedGraphMixin, RustWorkXGraph):
         ValueError
             If the node_id does not exist in the graph.
         """
-        if node_id not in self._external_to_local:
-            raise ValueError(f"Node {node_id} does not exist in the graph.")
+        self.bulk_remove_nodes([node_id])
 
-        local_node_id = self._map_to_local(node_id)
-        old_attrs = self._graph[local_node_id]
+    def bulk_remove_nodes(self, node_ids: Sequence[int]) -> None:
+        """
+        Remove multiple nodes from the graph, by external ID.
 
-        if is_signal_on(self.node_removed):
-            old_attrs = dict(self._graph[local_node_id])
+        Parameters
+        ----------
+        node_ids : Sequence[int]
+            The external IDs of the nodes to remove.
 
-        with self.node_removed.blocked():
-            super().remove_node(local_node_id)
+        Raises
+        ------
+        ValueError
+            If any node_id does not exist in the graph.
+        """
+        if hasattr(node_ids, "tolist"):
+            node_ids = node_ids.tolist()
+        else:
+            node_ids = list(node_ids)
+        if len(node_ids) == 0:
+            return
 
-        self._remove_id_mapping(external_id=node_id)
-        if is_signal_on(self.node_removed):
-            self.node_removed.emit(node_id, old_attrs)
+        missing = [nid for nid in node_ids if nid not in self._external_to_local]
+        if missing:
+            raise ValueError(f"Node {missing[0]} does not exist in the graph.")
+
+        local_ids = [self._external_to_local[nid] for nid in node_ids]
+
+        emit = is_signal_on(self.node_removed)
+        old_attrs_per_node = (
+            {nid: dict(self._graph[lid]) for nid, lid in zip(node_ids, local_ids, strict=True)} if emit else {}
+        )
+
+        # Local primitive: no signal emission, so no blocked() wrapper needed.
+        self._bulk_remove_nodes_local(local_ids)
+
+        for nid in node_ids:
+            self._remove_id_mapping(external_id=nid)
+
+        if emit:
+            for nid in node_ids:
+                self.node_removed.emit(nid, old_attrs_per_node[nid])
 
     def filter(
         self,

--- a/src/tracksdata/graph/_rustworkx_graph.py
+++ b/src/tracksdata/graph/_rustworkx_graph.py
@@ -559,45 +559,6 @@ class RustWorkXGraph(BaseGraph):
     # Public mutation API — validation + signals on top of the locals.
     # ------------------------------------------------------------------
 
-    def add_node(
-        self,
-        attrs: dict[str, Any],
-        validate_keys: bool = True,
-        index: int | None = None,
-    ) -> int:
-        """
-        Add a node to the graph at time t.
-
-        Parameters
-        ----------
-        attrs : Any
-            The attributes of the node to be added, must have a "t" key.
-            The keys of the attributes will be used as the attributes of the node.
-            For example:
-            ```python
-            graph.add_node(dict(t=0, label="A", intensity=100))
-            ```
-        validate_keys : bool
-            Whether to check if the attributes keys are valid.
-            If False, the attributes keys will not be checked,
-            useful to speed up the operation when doing bulk insertions.
-        index : int | None
-            Optional node index. RustWorkXGraph does not support custom indices
-            and will raise an error if this parameter is provided.
-        """
-        if index is not None:
-            raise ValueError("RustWorkXGraph does not support custom node indices. Use IndexedRXGraph instead.")
-
-        if validate_keys:
-            self._validate_attributes(attrs, self.node_attr_keys(), "node")
-            if "t" not in attrs:
-                raise ValueError(f"Node attributes must have a 't' key. Got {attrs.keys()}")
-
-        node_id = self._bulk_add_nodes_local([attrs])[0]
-        if is_signal_on(self.node_added):
-            self.node_added.emit(node_id, attrs)
-        return node_id
-
     def bulk_add_nodes(self, nodes: list[dict[str, Any]], indices: list[int] | None = None) -> list[int]:
         """
         Faster method to add multiple nodes to the graph with less overhead and fewer checks.
@@ -623,28 +584,6 @@ class RustWorkXGraph(BaseGraph):
         node_indices = self._bulk_add_nodes_local(nodes)
         emit_node_added_events(self.node_added, zip(node_indices, nodes, strict=True))
         return node_indices
-
-    def remove_node(self, node_id: int) -> None:
-        """
-        Remove a node from the graph.
-
-        This method removes the specified node and all edges connected to it
-        (both incoming and outgoing edges). Also updates the time_to_nodes mapping.
-
-        Parameters
-        ----------
-        node_id : int
-            The ID of the node to remove.
-
-        Raises
-        ------
-        ValueError
-            If the node_id does not exist in the graph.
-        """
-        emit = is_signal_on(self.node_removed)
-        captured = self._bulk_remove_nodes_local([node_id], capture_attrs=emit)
-        if emit:
-            self.node_removed.emit(node_id, captured[node_id])
 
     def bulk_remove_nodes(self, node_ids: Sequence[int]) -> None:
         """
@@ -1707,39 +1646,6 @@ class IndexedRXGraph(MappedGraphMixin, RustWorkXGraph):
     def supports_custom_indices(self) -> bool:
         return True
 
-    def add_node(
-        self,
-        attrs: dict[str, Any],
-        validate_keys: bool = True,
-        index: int | None = None,
-    ) -> int:
-        """
-        Add a node to the graph.
-
-        Parameters
-        ----------
-        attrs : dict[str, Any]
-            The attributes of the node.
-        validate_keys : bool
-            Whether to validate the keys of the attributes.
-        index : int | None
-            The index of the node. If None, the next available index will be used
-            to avoid conflicts with existing node indices.
-
-        Returns
-        -------
-        int
-            The index of the node.
-        """
-        if validate_keys:
-            self._validate_attributes(attrs, self.node_attr_keys(), "node")
-
-            if "t" not in attrs:
-                raise ValueError(f"Node attributes must have a 't' key. Got {attrs.keys()}")
-
-        indices = None if index is None else [index]
-        return self.bulk_add_nodes([attrs], indices=indices)[0]
-
     def bulk_add_nodes(
         self,
         nodes: list[dict[str, Any]],
@@ -2102,22 +2008,6 @@ class IndexedRXGraph(MappedGraphMixin, RustWorkXGraph):
                     for external_node_id, local_node_id in zip(external_node_ids, local_node_ids, strict=True)
                 ),
             )
-
-    def remove_node(self, node_id: int) -> None:
-        """
-        Remove a node from the graph.
-
-        Parameters
-        ----------
-        node_id : int
-            The external ID of the node to remove.
-
-        Raises
-        ------
-        ValueError
-            If the node_id does not exist in the graph.
-        """
-        self.bulk_remove_nodes([node_id])
 
     def bulk_remove_nodes(self, node_ids: Sequence[int]) -> None:
         """

--- a/src/tracksdata/graph/_rustworkx_graph.py
+++ b/src/tracksdata/graph/_rustworkx_graph.py
@@ -644,27 +644,6 @@ class RustWorkXGraph(BaseGraph):
         edge_ids = self._bulk_add_edges_local(edges)
         return edge_ids if return_ids else None
 
-    def remove_edge(
-        self,
-        source_id: int | None = None,
-        target_id: int | None = None,
-        *,
-        edge_id: int | None = None,
-    ) -> None:
-        """
-        Remove an edge by ID or by endpoints.
-        """
-        if edge_id is not None:
-            self._bulk_remove_edges_local([edge_id])
-            return
-
-        if source_id is None or target_id is None:
-            raise ValueError("Provide either edge_id or both source_id and target_id.")
-        try:
-            self.rx_graph.remove_edge(source_id, target_id)
-        except rx.NoEdgeBetweenNodes as e:
-            raise ValueError(f"Edge {source_id}->{target_id} does not exist in the graph.") from e
-
     def bulk_remove_edges(self, edge_ids: Sequence[int]) -> None:
         """
         Remove multiple edges from the graph by their edge IDs.
@@ -1536,8 +1515,16 @@ class RustWorkXGraph(BaseGraph):
     def edge_id(self, source_id: int, target_id: int) -> int:
         """
         Return the edge id between two nodes.
+
+        Raises
+        ------
+        ValueError
+            If there is no edge between the two nodes.
         """
-        return self.rx_graph.get_edge_data(source_id, target_id)[DEFAULT_ATTR_KEYS.EDGE_ID]
+        try:
+            return self.rx_graph.get_edge_data(source_id, target_id)[DEFAULT_ATTR_KEYS.EDGE_ID]
+        except rx.NoEdgeBetweenNodes as e:
+            raise ValueError(f"Edge {source_id}->{target_id} does not exist in the graph.") from e
 
     def _metadata(self) -> dict[str, Any]:
         return self._graph.attrs
@@ -1818,30 +1805,6 @@ class IndexedRXGraph(MappedGraphMixin, RustWorkXGraph):
             edge[DEFAULT_ATTR_KEYS.EDGE_TARGET] = self._map_to_local(edge[DEFAULT_ATTR_KEYS.EDGE_TARGET])
         return super().bulk_add_edges(edges, return_ids=return_ids)
 
-    def remove_edge(
-        self,
-        source_id: int | None = None,
-        target_id: int | None = None,
-        *,
-        edge_id: int | None = None,
-    ) -> None:
-        """
-        Remove an edge by endpoints (external IDs) or by edge_id.
-        """
-        if edge_id is not None:
-            return super().remove_edge(edge_id=edge_id)
-        if source_id is None or target_id is None:
-            raise ValueError("Provide either edge_id or both source_id and target_id.")
-        try:
-            local_source = self._map_to_local(source_id)
-            local_target = self._map_to_local(target_id)
-        except KeyError as e:
-            raise ValueError(f"Edge {source_id}->{target_id} does not exist in the graph.") from e
-        try:
-            return super().remove_edge(local_source, local_target)
-        except ValueError as e:
-            raise ValueError(f"Edge {source_id}->{target_id} does not exist in the graph.") from e
-
     def add_overlap(self, source_id: int, target_id: int) -> int:
         """
         Add an overlap to the graph.
@@ -2012,7 +1975,15 @@ class IndexedRXGraph(MappedGraphMixin, RustWorkXGraph):
     def edge_id(self, source_id: int, target_id: int) -> int:
         """
         Return the edge id between two nodes.
+
+        Raises
+        ------
+        ValueError
+            If either node is unknown or there is no edge between them.
         """
-        source_id = self._map_to_local(source_id)
-        target_id = self._map_to_local(target_id)
-        return super().edge_id(source_id, target_id)
+        try:
+            local_source = self._map_to_local(source_id)
+            local_target = self._map_to_local(target_id)
+            return super().edge_id(local_source, local_target)
+        except (KeyError, ValueError) as e:
+            raise ValueError(f"Edge {source_id}->{target_id} does not exist in the graph.") from e

--- a/src/tracksdata/graph/_rustworkx_graph.py
+++ b/src/tracksdata/graph/_rustworkx_graph.py
@@ -611,34 +611,6 @@ class RustWorkXGraph(BaseGraph):
         if emit:
             emit_node_removed_events(self.node_removed, ((nid, captured[nid]) for nid in node_ids))
 
-    def add_edge(
-        self,
-        source_id: int,
-        target_id: int,
-        attrs: dict[str, Any],
-        validate_keys: bool = True,
-    ) -> int:
-        """
-        Add an edge to the graph.
-
-        Parameters
-        ----------
-        source_id : int
-            The ID of the source node.
-        target_id : int
-            The ID of the target node.
-        attrs : dict[str, Any]
-            The attributes of the edge to be added.
-            The keys of the attributes will be used as the attributes of the edge.
-        validate_keys : bool
-            Whether to check if the attributes keys are valid.
-            If False, the attributes keys will not be checked,
-            useful to speed up the operation when doing bulk insertions.
-        """
-        if validate_keys:
-            self._validate_attributes(attrs, self.edge_attr_keys(), "edge")
-        return self._add_edge_local(source_id, target_id, attrs)
-
     def bulk_add_edges(self, edges: list[dict[str, Any]], return_ids: bool = False) -> list[int] | None:
         """
         Faster method to add multiple edges to the graph with less overhead and fewer checks.
@@ -1829,36 +1801,6 @@ class IndexedRXGraph(MappedGraphMixin, RustWorkXGraph):
         Get the node ids of dividing nodes (nodes with out-degree == 2).
         """
         return self._map_to_external(super().dividing_nodes())
-
-    def add_edge(
-        self,
-        source_id: int,
-        target_id: int,
-        attrs: dict[str, Any],
-        validate_keys: bool = True,
-    ) -> int:
-        """
-        Add an edge to the graph.
-
-        Parameters
-        ----------
-        source_id : int
-            The source node id.
-        target_id : int
-            The target node id.
-        attrs : dict[str, Any]
-            The attributes of the edge.
-        validate_keys : bool
-            Whether to validate the keys of the attributes.
-
-        Returns
-        -------
-        int
-            The edge id.
-        """
-        source_id = self._map_to_local(source_id)
-        target_id = self._map_to_local(target_id)
-        return super().add_edge(source_id, target_id, attrs, validate_keys)
 
     def bulk_add_edges(
         self,

--- a/src/tracksdata/graph/_rustworkx_graph.py
+++ b/src/tracksdata/graph/_rustworkx_graph.py
@@ -18,6 +18,7 @@ from tracksdata.utils._dtypes import AttrSchema, process_attr_key_args
 from tracksdata.utils._logging import LOG
 from tracksdata.utils._signal import (
     emit_node_added_events,
+    emit_node_removed_events,
     emit_node_updated_events,
     is_signal_on,
 )
@@ -669,8 +670,7 @@ class RustWorkXGraph(BaseGraph):
         emit = is_signal_on(self.node_removed)
         captured = self._bulk_remove_nodes_local(node_ids, capture_attrs=emit)
         if emit:
-            for nid in node_ids:
-                self.node_removed.emit(nid, captured[nid])
+            emit_node_removed_events(self.node_removed, ((nid, captured[nid]) for nid in node_ids))
 
     def add_edge(
         self,
@@ -2158,8 +2158,7 @@ class IndexedRXGraph(MappedGraphMixin, RustWorkXGraph):
             self._remove_id_mapping(external_id=nid)
 
         if emit:
-            for nid in node_ids:
-                self.node_removed.emit(nid, old_attrs_per_node[nid])
+            emit_node_removed_events(self.node_removed, ((nid, old_attrs_per_node[nid]) for nid in node_ids))
 
     def filter(
         self,

--- a/src/tracksdata/graph/_sql_graph.py
+++ b/src/tracksdata/graph/_sql_graph.py
@@ -30,7 +30,11 @@ from tracksdata.utils._dtypes import (
     sqlalchemy_type_to_polars_dtype,
 )
 from tracksdata.utils._logging import LOG
-from tracksdata.utils._signal import is_signal_on
+from tracksdata.utils._signal import (
+    emit_node_added_events,
+    emit_node_updated_events,
+    is_signal_on,
+)
 
 if TYPE_CHECKING:
     from tracksdata.graph._graph_view import GraphView
@@ -792,31 +796,8 @@ class SQLGraph(BaseGraph):
             if "t" not in attrs:
                 raise ValueError(f"Node attributes must have a 't' key. Got {attrs.keys()}")
 
-        time = attrs["t"]
-
-        if index is None:
-            default_node_id = (time * self.node_id_time_multiplier) - 1
-            node_id = self._max_id_per_time.get(time, default_node_id) + 1
-        else:
-            node_id = index
-
-        node = self.Node(
-            node_id=node_id,
-            **attrs,
-        )
-
-        with Session(self._engine) as session:
-            session.add(node)
-            session.commit()
-
-        # Update max_id tracking only if using auto-generated IDs
-        if index is None:
-            self._max_id_per_time[time] = node_id
-
-        if is_signal_on(self.node_added):
-            self.node_added.emit(node_id, attrs)
-
-        return node_id
+        indices = None if index is None else [index]
+        return self.bulk_add_nodes([attrs], indices=indices)[0]
 
     def bulk_add_nodes(
         self,
@@ -864,6 +845,7 @@ class SQLGraph(BaseGraph):
         self._validate_indices_length(nodes, indices)
 
         node_ids = []
+        insert_rows = []
         for i, node in enumerate(nodes):
             time = node["t"]
 
@@ -875,15 +857,12 @@ class SQLGraph(BaseGraph):
             else:
                 node_id = indices[i]
 
-            node[DEFAULT_ATTR_KEYS.NODE_ID] = node_id
             node_ids.append(node_id)
+            insert_rows.append({**node, DEFAULT_ATTR_KEYS.NODE_ID: node_id})
 
-        self._chunked_sa_write(Session.bulk_insert_mappings, nodes, self.Node)
+        self._chunked_sa_write(Session.bulk_insert_mappings, insert_rows, self.Node)
 
-        if is_signal_on(self.node_added):
-            for node_id, node_attrs in zip(node_ids, nodes, strict=True):
-                new_attrs = {key: value for key, value in node_attrs.items() if key != DEFAULT_ATTR_KEYS.NODE_ID}
-                self.node_added.emit(node_id, new_attrs)
+        emit_node_added_events(self.node_added, zip(node_ids, nodes, strict=True))
 
         return node_ids
 
@@ -905,32 +884,67 @@ class SQLGraph(BaseGraph):
         ValueError
             If the node_id does not exist in the graph.
         """
+        self.bulk_remove_nodes([node_id])
+
+    def bulk_remove_nodes(self, node_ids: Sequence[int]) -> None:
+        """
+        Remove multiple nodes from the graph, along with their incident edges and overlaps.
+
+        Parameters
+        ----------
+        node_ids : Sequence[int]
+            The IDs of the nodes to remove.
+
+        Raises
+        ------
+        ValueError
+            If any node_id does not exist in the graph.
+        """
+        if hasattr(node_ids, "tolist"):
+            node_ids = node_ids.tolist()
+        else:
+            node_ids = list(node_ids)
+
+        if len(node_ids) == 0:
+            return
+
+        emit_signal = is_signal_on(self.node_removed)
+        chunk_size = self._sql_chunk_size()
+
         with Session(self._engine) as session:
-            # Check if the node exists
-            node = session.query(self.Node).filter(self.Node.node_id == node_id).first()
-            if node is None:
-                raise ValueError(f"Node {node_id} does not exist in the graph.")
-            old_attrs = {key: getattr(node, key) for key in self.node_attr_keys()}
-            self.node_removed.emit(node_id, old_attrs)
+            # Validate that all requested node ids exist before doing any destructive work.
+            existing: set[int] = set()
+            for i in range(0, len(node_ids), chunk_size):
+                chunk = node_ids[i : i + chunk_size]
+                existing.update(
+                    row[0] for row in session.query(self.Node.node_id).filter(self.Node.node_id.in_(chunk)).all()
+                )
+            missing = [nid for nid in node_ids if nid not in existing]
+            if missing:
+                raise ValueError(f"Node {missing[0]} does not exist in the graph.")
 
-            if is_signal_on(self.node_removed):
-                old_attrs = {key: getattr(node, key) for key in self.node_attr_keys()}
+            old_attrs_per_node: dict[int, dict[str, Any]] = {}
+            if emit_signal:
+                attr_keys = self.node_attr_keys()
+                for i in range(0, len(node_ids), chunk_size):
+                    chunk = node_ids[i : i + chunk_size]
+                    for node in session.query(self.Node).filter(self.Node.node_id.in_(chunk)).all():
+                        old_attrs_per_node[node.node_id] = {key: getattr(node, key) for key in attr_keys}
 
-            # Remove all edges where this node is source or target
-            session.query(self.Edge).filter(
-                sa.or_(self.Edge.source_id == node_id, self.Edge.target_id == node_id)
-            ).delete()
-
-            # Remove all overlaps involving this node
-            session.query(self.Overlap).filter(
-                sa.or_(self.Overlap.source_id == node_id, self.Overlap.target_id == node_id)
-            ).delete()
-
-            # Remove the node itself
-            session.delete(node)
+            for i in range(0, len(node_ids), chunk_size):
+                chunk = node_ids[i : i + chunk_size]
+                session.query(self.Edge).filter(
+                    sa.or_(self.Edge.source_id.in_(chunk), self.Edge.target_id.in_(chunk))
+                ).delete(synchronize_session=False)
+                session.query(self.Overlap).filter(
+                    sa.or_(self.Overlap.source_id.in_(chunk), self.Overlap.target_id.in_(chunk))
+                ).delete(synchronize_session=False)
+                session.query(self.Node).filter(self.Node.node_id.in_(chunk)).delete(synchronize_session=False)
             session.commit()
-            if is_signal_on(self.node_removed):
-                self.node_removed.emit(node_id, old_attrs)
+
+        if emit_signal:
+            for nid in node_ids:
+                self.node_removed.emit(nid, old_attrs_per_node[nid])
 
     def add_edge(
         self,
@@ -980,18 +994,12 @@ class SQLGraph(BaseGraph):
         if hasattr(target_id, "item"):
             target_id = target_id.item()
 
-        edge = self.Edge(
-            source_id=source_id,
-            target_id=target_id,
+        edge = {
+            DEFAULT_ATTR_KEYS.EDGE_SOURCE: source_id,
+            DEFAULT_ATTR_KEYS.EDGE_TARGET: target_id,
             **attrs,
-        )
-
-        with Session(self._engine) as session:
-            session.add(edge)
-            session.commit()
-            edge_id = edge.edge_id
-
-        return edge_id
+        }
+        return self.bulk_add_edges([edge], return_ids=True)[0]
 
     def bulk_add_edges(
         self,
@@ -1974,18 +1982,10 @@ class SQLGraph(BaseGraph):
             new_attrs_by_id = new_df.rows_by_key(
                 key=DEFAULT_ATTR_KEYS.NODE_ID, named=True, unique=True, include_key=True
             )
-
-            for node_id in updated_node_ids:
-                self.node_updated.emit(node_id, old_attrs_by_id[node_id], new_attrs_by_id[node_id])
-
-            new_df = self.filter(node_ids=updated_node_ids).node_attrs(
-                attr_keys=[DEFAULT_ATTR_KEYS.NODE_ID, *attr_keys]
+            emit_node_updated_events(
+                self.node_updated,
+                ((node_id, old_attrs_by_id[node_id], new_attrs_by_id[node_id]) for node_id in updated_node_ids),
             )
-            new_attrs_by_id = new_df.rows_by_key(
-                key=DEFAULT_ATTR_KEYS.NODE_ID, named=True, unique=True, include_key=True
-            )
-            for node_id in updated_node_ids:
-                self.node_updated.emit(node_id, old_attrs_by_id[node_id], new_attrs_by_id[node_id])
 
     def update_edge_attrs(
         self,
@@ -2384,21 +2384,60 @@ class SQLGraph(BaseGraph):
         """
         Remove an edge from the graph either by its ID or by its endpoints.
         """
+        if edge_id is not None:
+            self.bulk_remove_edges([edge_id])
+            return
+
+        if source_id is None or target_id is None:
+            raise ValueError("Provide either edge_id or both source_id and target_id.")
+
         with Session(self._engine) as session:
-            if edge_id is None:
-                if source_id is None or target_id is None:
-                    raise ValueError("Provide either edge_id or both source_id and target_id.")
-                deleted = (
-                    session.query(self.Edge)
-                    .filter(self.Edge.source_id == source_id, self.Edge.target_id == target_id)
-                    .delete()
+            deleted = (
+                session.query(self.Edge)
+                .filter(self.Edge.source_id == source_id, self.Edge.target_id == target_id)
+                .delete()
+            )
+            if not deleted:
+                raise ValueError(f"Edge {source_id}->{target_id} does not exist in the graph.")
+            session.commit()
+
+    def bulk_remove_edges(self, edge_ids: Sequence[int]) -> None:
+        """
+        Remove multiple edges from the graph by their edge IDs.
+
+        Parameters
+        ----------
+        edge_ids : Sequence[int]
+            The IDs of the edges to remove.
+
+        Raises
+        ------
+        ValueError
+            If any edge_id does not exist in the graph.
+        """
+        if hasattr(edge_ids, "tolist"):
+            edge_ids = edge_ids.tolist()
+        else:
+            edge_ids = list(edge_ids)
+
+        if len(edge_ids) == 0:
+            return
+
+        chunk_size = self._sql_chunk_size()
+        with Session(self._engine) as session:
+            existing: set[int] = set()
+            for i in range(0, len(edge_ids), chunk_size):
+                chunk = edge_ids[i : i + chunk_size]
+                existing.update(
+                    row[0] for row in session.query(self.Edge.edge_id).filter(self.Edge.edge_id.in_(chunk)).all()
                 )
-                if not deleted:
-                    raise ValueError(f"Edge {source_id}->{target_id} does not exist in the graph.")
-            else:
-                deleted = session.query(self.Edge).filter(self.Edge.edge_id == edge_id).delete()
-                if not deleted:
-                    raise ValueError(f"Edge {edge_id} does not exist in the graph.")
+            missing = [eid for eid in edge_ids if eid not in existing]
+            if missing:
+                raise ValueError(f"Edge {missing[0]} does not exist in the graph.")
+
+            for i in range(0, len(edge_ids), chunk_size):
+                chunk = edge_ids[i : i + chunk_size]
+                session.query(self.Edge).filter(self.Edge.edge_id.in_(chunk)).delete(synchronize_session=False)
             session.commit()
 
     def _metadata(self) -> dict[str, Any]:

--- a/src/tracksdata/graph/_sql_graph.py
+++ b/src/tracksdata/graph/_sql_graph.py
@@ -34,6 +34,7 @@ from tracksdata.utils._dtypes import (
 from tracksdata.utils._logging import LOG
 from tracksdata.utils._signal import (
     emit_node_added_events,
+    emit_node_removed_events,
     emit_node_updated_events,
     is_signal_on,
 )
@@ -1041,8 +1042,7 @@ class SQLGraph(BaseGraph):
             session.commit()
 
         if emit_signal:
-            for nid in node_ids:
-                self.node_removed.emit(nid, old_attrs_per_node[nid])
+            emit_node_removed_events(self.node_removed, ((nid, old_attrs_per_node[nid]) for nid in node_ids))
 
     def add_edge(
         self,
@@ -2577,20 +2577,31 @@ class SQLGraph(BaseGraph):
             return
 
         chunk_size = self._sql_chunk_size()
+        unique_ids = set(edge_ids)
         with Session(self._engine) as session:
-            existing: set[int] = set()
+            # Delete and count in a single pass; the delete rowcount tells us how
+            # many of the requested edges actually existed, avoiding a separate
+            # existence query on the happy path.
+            deleted = 0
             for i in range(0, len(edge_ids), chunk_size):
                 chunk = edge_ids[i : i + chunk_size]
-                existing.update(
-                    row[0] for row in session.query(self.Edge.edge_id).filter(self.Edge.edge_id.in_(chunk)).all()
+                deleted += (
+                    session.query(self.Edge).filter(self.Edge.edge_id.in_(chunk)).delete(synchronize_session=False)
                 )
-            missing = [eid for eid in edge_ids if eid not in existing]
-            if missing:
+
+            if deleted != len(unique_ids):
+                # Some requested edges were missing: discard the deletes instead
+                # of committing, then identify a missing id for the error message.
+                session.rollback()
+                existing: set[int] = set()
+                for i in range(0, len(edge_ids), chunk_size):
+                    chunk = edge_ids[i : i + chunk_size]
+                    existing.update(
+                        row[0] for row in session.query(self.Edge.edge_id).filter(self.Edge.edge_id.in_(chunk)).all()
+                    )
+                missing = [eid for eid in edge_ids if eid not in existing]
                 raise ValueError(f"Edge {missing[0]} does not exist in the graph.")
 
-            for i in range(0, len(edge_ids), chunk_size):
-                chunk = edge_ids[i : i + chunk_size]
-                session.query(self.Edge).filter(self.Edge.edge_id.in_(chunk)).delete(synchronize_session=False)
             session.commit()
 
     def _metadata(self) -> dict[str, Any]:

--- a/src/tracksdata/graph/_sql_graph.py
+++ b/src/tracksdata/graph/_sql_graph.py
@@ -936,18 +936,8 @@ class SQLGraph(BaseGraph):
         emit_signal = is_signal_on(self.node_removed)
         chunk_size = self._sql_chunk_size()
 
+        unique_ids = set(node_ids)
         with Session(self._engine) as session:
-            # Validate that all requested node ids exist before doing any destructive work.
-            existing: set[int] = set()
-            for i in range(0, len(node_ids), chunk_size):
-                chunk = node_ids[i : i + chunk_size]
-                existing.update(
-                    row[0] for row in session.query(self.Node.node_id).filter(self.Node.node_id.in_(chunk)).all()
-                )
-            missing = [nid for nid in node_ids if nid not in existing]
-            if missing:
-                raise ValueError(f"Node {missing[0]} does not exist in the graph.")
-
             old_attrs_per_node: dict[int, dict[str, Any]] = {}
             if emit_signal:
                 attr_keys = self.node_attr_keys()
@@ -956,6 +946,10 @@ class SQLGraph(BaseGraph):
                     for node in session.query(self.Node).filter(self.Node.node_id.in_(chunk)).all():
                         old_attrs_per_node[node.node_id] = {key: getattr(node, key) for key in attr_keys}
 
+            # Delete incident edges/overlaps and the nodes in a single pass; the node
+            # delete rowcount tells us how many requested nodes actually existed,
+            # avoiding a separate up-front existence query on the happy path.
+            deleted = 0
             for i in range(0, len(node_ids), chunk_size):
                 chunk = node_ids[i : i + chunk_size]
                 session.query(self.Edge).filter(
@@ -964,7 +958,23 @@ class SQLGraph(BaseGraph):
                 session.query(self.Overlap).filter(
                     sa.or_(self.Overlap.source_id.in_(chunk), self.Overlap.target_id.in_(chunk))
                 ).delete(synchronize_session=False)
-                session.query(self.Node).filter(self.Node.node_id.in_(chunk)).delete(synchronize_session=False)
+                deleted += (
+                    session.query(self.Node).filter(self.Node.node_id.in_(chunk)).delete(synchronize_session=False)
+                )
+
+            if deleted != len(unique_ids):
+                # Some requested nodes were missing: discard the deletes instead of
+                # committing, then identify a missing id for the error message.
+                session.rollback()
+                existing: set[int] = set()
+                for i in range(0, len(node_ids), chunk_size):
+                    chunk = node_ids[i : i + chunk_size]
+                    existing.update(
+                        row[0] for row in session.query(self.Node.node_id).filter(self.Node.node_id.in_(chunk)).all()
+                    )
+                missing = [nid for nid in node_ids if nid not in existing]
+                raise ValueError(f"Node {missing[0]} does not exist in the graph.")
+
             session.commit()
 
         if emit_signal:

--- a/src/tracksdata/graph/_sql_graph.py
+++ b/src/tracksdata/graph/_sql_graph.py
@@ -970,61 +970,6 @@ class SQLGraph(BaseGraph):
         if emit_signal:
             emit_node_removed_events(self.node_removed, ((nid, old_attrs_per_node[nid]) for nid in node_ids))
 
-    def add_edge(
-        self,
-        source_id: int,
-        target_id: int,
-        attrs: dict[str, Any],
-        validate_keys: bool = True,
-    ) -> int:
-        """
-        Add an edge to the graph.
-
-        Parameters
-        ----------
-        source_id : int
-            The ID of the source node.
-        target_id : int
-            The ID of the target node.
-        attrs : dict[str, Any]
-            Additional attributes for the edge (e.g., weight, distance).
-        validate_keys : bool, default True
-            Whether to check if the attribute keys are valid against the
-            current schema. If False, validation is skipped for performance.
-
-        Returns
-        -------
-        int
-            The ID of the newly added edge.
-
-        Raises
-        ------
-        ValueError
-            If validate_keys is True and the attributes contain invalid keys.
-
-        Examples
-        --------
-        ```python
-        edge_id = graph.add_edge(node1_id, node2_id, {"weight": 0.8})
-        edge_id = graph.add_edge(node1_id, node2_id, {"weight": 0.9, "distance": 5.2, "confidence": 0.95})
-        ```
-        """
-        if validate_keys:
-            self._validate_attributes(attrs, self.edge_attr_keys(), "edge")
-
-        if hasattr(source_id, "item"):
-            source_id = source_id.item()
-
-        if hasattr(target_id, "item"):
-            target_id = target_id.item()
-
-        edge = {
-            DEFAULT_ATTR_KEYS.EDGE_SOURCE: source_id,
-            DEFAULT_ATTR_KEYS.EDGE_TARGET: target_id,
-            **attrs,
-        }
-        return self.bulk_add_edges([edge], return_ids=True)[0]
-
     def bulk_add_edges(
         self,
         edges: list[dict[str, Any]],

--- a/src/tracksdata/graph/_sql_graph.py
+++ b/src/tracksdata/graph/_sql_graph.py
@@ -844,60 +844,6 @@ class SQLGraph(BaseGraph):
             include_sources=include_sources,
         )
 
-    def add_node(
-        self,
-        attrs: dict[str, Any],
-        validate_keys: bool = True,
-        index: int | None = None,
-    ) -> int:
-        """
-        Add a node to the graph at time t.
-
-        Node IDs are automatically generated based on the time point and
-        the node_id_time_multiplier to ensure uniqueness across time points,
-        unless an explicit index is provided.
-
-        Parameters
-        ----------
-        attrs : dict[str, Any]
-            The attributes of the node to be added. Must contain a "t" key
-            specifying the time point. Additional keys will be stored as
-            node attributes.
-        validate_keys : bool, default True
-            Whether to check if the attribute keys are valid against the
-            current schema. If False, validation is skipped for performance.
-        index : int | None, default None
-            Optional specific node ID to use. If provided, this will be used
-            as the node_id instead of the auto-generated value.
-
-        Returns
-        -------
-        int
-            The ID of the newly added node.
-
-        Raises
-        ------
-        ValueError
-            If validate_keys is True and the attributes contain invalid keys,
-            or if the "t" key is missing.
-
-        Examples
-        --------
-        ```python
-        node_id = graph.add_node({"t": 0, "x": 10.5, "y": 20.3})
-        node_id = graph.add_node({"t": 1, "x": 15.2, "y": 25.8, "intensity": 150.0})
-        node_id = graph.add_node({"t": 0, "x": 20.0, "y": 30.0}, index=12345)
-        ```
-        """
-        if validate_keys:
-            self._validate_attributes(attrs, self.node_attr_keys(), "node")
-
-            if "t" not in attrs:
-                raise ValueError(f"Node attributes must have a 't' key. Got {attrs.keys()}")
-
-        indices = None if index is None else [index]
-        return self.bulk_add_nodes([attrs], indices=indices)[0]
-
     def bulk_add_nodes(
         self,
         nodes: list[dict[str, Any]],
@@ -964,26 +910,6 @@ class SQLGraph(BaseGraph):
         emit_node_added_events(self.node_added, zip(node_ids, nodes, strict=True))
 
         return node_ids
-
-    def remove_node(self, node_id: int) -> None:
-        """
-        Remove a node from the graph.
-
-        This method removes the specified node and all edges connected to it
-        (both incoming and outgoing edges). Also removes any overlaps
-        involving this node.
-
-        Parameters
-        ----------
-        node_id : int
-            The ID of the node to remove.
-
-        Raises
-        ------
-        ValueError
-            If the node_id does not exist in the graph.
-        """
-        self.bulk_remove_nodes([node_id])
 
     def bulk_remove_nodes(self, node_ids: Sequence[int]) -> None:
         """

--- a/src/tracksdata/graph/_sql_graph.py
+++ b/src/tracksdata/graph/_sql_graph.py
@@ -2398,33 +2398,6 @@ class SQLGraph(BaseGraph):
                 raise ValueError(f"Edge {source_id}->{target_id} does not exist in the graph.")
             return edge_id
 
-    def remove_edge(
-        self,
-        source_id: int | None = None,
-        target_id: int | None = None,
-        *,
-        edge_id: int | None = None,
-    ) -> None:
-        """
-        Remove an edge from the graph either by its ID or by its endpoints.
-        """
-        if edge_id is not None:
-            self.bulk_remove_edges([edge_id])
-            return
-
-        if source_id is None or target_id is None:
-            raise ValueError("Provide either edge_id or both source_id and target_id.")
-
-        with Session(self._engine) as session:
-            deleted = (
-                session.query(self.Edge)
-                .filter(self.Edge.source_id == source_id, self.Edge.target_id == target_id)
-                .delete()
-            )
-            if not deleted:
-                raise ValueError(f"Edge {source_id}->{target_id} does not exist in the graph.")
-            session.commit()
-
     def bulk_remove_edges(self, edge_ids: Sequence[int]) -> None:
         """
         Remove multiple edges from the graph by their edge IDs.

--- a/src/tracksdata/graph/_test/test_graph_backends.py
+++ b/src/tracksdata/graph/_test/test_graph_backends.py
@@ -519,6 +519,38 @@ def test_update_node_attrs(graph_backend: BaseGraph) -> None:
         graph_backend.update_node_attrs(node_ids=[node_1, node_2], attrs={"x": [1.0]})
 
 
+def test_bulk_add_nodes_emits_batched_node_added_callback(graph_backend: BaseGraph) -> None:
+    graph_backend.add_node_attr_key("x", pl.Float64)
+
+    calls: list[tuple[Any, Any]] = []
+    graph_backend.node_added.connect(lambda node_ids, attrs: calls.append((node_ids, attrs)))
+
+    nodes = [{"t": 0, "x": 1.0}, {"t": 1, "x": 2.0}, {"t": 1, "x": 3.0}]
+    node_ids = graph_backend.bulk_add_nodes(nodes)
+
+    assert len(calls) == 1
+    assert calls[0][0] == node_ids
+    assert calls[0][1] == nodes
+
+
+def test_update_node_attrs_emits_batched_node_updated_callback(graph_backend: BaseGraph) -> None:
+    graph_backend.add_node_attr_key("x", pl.Float64)
+
+    node_ids = graph_backend.bulk_add_nodes([{"t": 0, "x": 1.0}, {"t": 1, "x": 2.0}, {"t": 1, "x": 3.0}])
+
+    calls: list[tuple[Any, Any, Any]] = []
+    graph_backend.node_updated.connect(
+        lambda node_ids, old_attrs, new_attrs: calls.append((node_ids, old_attrs, new_attrs))
+    )
+
+    graph_backend.update_node_attrs(node_ids=node_ids, attrs={"x": [10.0, 20.0, 30.0]})
+
+    assert len(calls) == 1
+    assert calls[0][0] == node_ids
+    assert [attrs["x"] for attrs in calls[0][1]] == [1.0, 2.0, 3.0]
+    assert [attrs["x"] for attrs in calls[0][2]] == [10.0, 20.0, 30.0]
+
+
 def test_update_edge_attrs(graph_backend: BaseGraph) -> None:
     """Test updating edge attributes."""
     node1 = graph_backend.add_node({"t": 0})
@@ -2509,6 +2541,108 @@ def test_remove_all_nodes_in_time_point(graph_backend: BaseGraph) -> None:
     graph_backend.remove_node(node3)
     time_points_after_two = set(graph_backend.time_points())
     assert time_points_after_two == {0, 2}  # t=1 should be gone
+
+
+def test_bulk_remove_nodes(graph_backend: BaseGraph) -> None:
+    """bulk_remove_nodes drops nodes, incident edges, and overlaps in one call."""
+    graph_backend.add_node_attr_key("x", dtype=pl.Float64)
+    graph_backend.add_edge_attr_key("weight", dtype=pl.Float64)
+
+    n1 = graph_backend.add_node({"t": 0, "x": 1.0})
+    n2 = graph_backend.add_node({"t": 1, "x": 2.0})
+    n3 = graph_backend.add_node({"t": 2, "x": 3.0})
+    n4 = graph_backend.add_node({"t": 3, "x": 4.0})
+
+    e12 = graph_backend.add_edge(n1, n2, {"weight": 0.1})
+    graph_backend.add_edge(n2, n3, {"weight": 0.2})
+    e34 = graph_backend.add_edge(n3, n4, {"weight": 0.3})
+
+    graph_backend.add_overlap(n2, n3)
+    graph_backend.add_overlap(n1, n4)
+
+    graph_backend.bulk_remove_nodes([n2, n3])
+
+    assert set(graph_backend.node_ids()) == {n1, n4}
+    remaining_edges = set(graph_backend.edge_ids())
+    assert e12 not in remaining_edges
+    assert e34 not in remaining_edges
+    assert graph_backend.num_edges() == 0
+
+    overlaps = graph_backend.overlaps()
+    assert [n1, n4] in overlaps
+    assert all(n2 not in pair and n3 not in pair for pair in overlaps)
+
+
+def test_bulk_remove_nodes_empty_is_noop(graph_backend: BaseGraph) -> None:
+    n1 = graph_backend.add_node({"t": 0})
+    graph_backend.bulk_remove_nodes([])
+    assert graph_backend.num_nodes() == 1
+    assert n1 in graph_backend.node_ids()
+
+
+def test_bulk_remove_nodes_raises_when_missing(graph_backend: BaseGraph) -> None:
+    """bulk_remove_nodes is atomic: missing IDs raise without mutating the graph."""
+    n1 = graph_backend.add_node({"t": 0})
+    n2 = graph_backend.add_node({"t": 1})
+
+    with pytest.raises(ValueError, match=r"Node .* does not exist in the graph."):
+        graph_backend.bulk_remove_nodes([n1, 99999])
+
+    assert set(graph_backend.node_ids()) == {n1, n2}
+
+
+def test_bulk_remove_nodes_emits_signal(graph_backend: BaseGraph) -> None:
+    n1 = graph_backend.add_node({"t": 0})
+    n2 = graph_backend.add_node({"t": 1})
+
+    observed: list[int] = []
+    graph_backend.node_removed.connect(lambda nid, _attrs: observed.append(nid))
+
+    graph_backend.bulk_remove_nodes([n1, n2])
+    assert observed == [n1, n2]
+
+
+def test_bulk_remove_edges(graph_backend: BaseGraph) -> None:
+    graph_backend.add_node_attr_key("x", dtype=pl.Float64)
+    graph_backend.add_edge_attr_key("weight", dtype=pl.Float64)
+
+    n1 = graph_backend.add_node({"t": 0, "x": 1.0})
+    n2 = graph_backend.add_node({"t": 1, "x": 2.0})
+    n3 = graph_backend.add_node({"t": 2, "x": 3.0})
+
+    e12 = graph_backend.add_edge(n1, n2, {"weight": 0.1})
+    e23 = graph_backend.add_edge(n2, n3, {"weight": 0.2})
+    e13 = graph_backend.add_edge(n1, n3, {"weight": 0.3})
+
+    graph_backend.bulk_remove_edges([e12, e23])
+
+    assert set(graph_backend.node_ids()) == {n1, n2, n3}
+    assert set(graph_backend.edge_ids()) == {e13}
+    assert not graph_backend.has_edge(n1, n2)
+    assert not graph_backend.has_edge(n2, n3)
+    assert graph_backend.has_edge(n1, n3)
+
+
+def test_bulk_remove_edges_empty_is_noop(graph_backend: BaseGraph) -> None:
+    n1 = graph_backend.add_node({"t": 0})
+    n2 = graph_backend.add_node({"t": 1})
+    graph_backend.add_edge_attr_key("weight", dtype=pl.Float64)
+    e = graph_backend.add_edge(n1, n2, {"weight": 0.1})
+
+    graph_backend.bulk_remove_edges([])
+    assert set(graph_backend.edge_ids()) == {e}
+
+
+def test_bulk_remove_edges_raises_when_missing(graph_backend: BaseGraph) -> None:
+    n1 = graph_backend.add_node({"t": 0})
+    n2 = graph_backend.add_node({"t": 1})
+    graph_backend.add_edge_attr_key("weight", dtype=pl.Float64)
+    e = graph_backend.add_edge(n1, n2, {"weight": 0.1})
+
+    with pytest.raises(ValueError, match=r"Edge .* does not exist in the graph."):
+        graph_backend.bulk_remove_edges([e, 99999])
+
+    assert set(graph_backend.edge_ids()) == {e}
 
 
 def _fill_mock_geff_graph(graph_backend: BaseGraph) -> None:

--- a/src/tracksdata/graph/_test/test_graph_backends.py
+++ b/src/tracksdata/graph/_test/test_graph_backends.py
@@ -2596,7 +2596,7 @@ def test_bulk_remove_nodes_emits_signal(graph_backend: BaseGraph) -> None:
     n2 = graph_backend.add_node({"t": 1})
 
     observed: list[int] = []
-    graph_backend.node_removed.connect(lambda nid, _attrs: observed.append(nid))
+    graph_backend.node_removed.connect(lambda node_ids, _attrs: observed.extend(node_ids))
 
     graph_backend.bulk_remove_nodes([n1, n2])
     assert observed == [n1, n2]

--- a/src/tracksdata/graph/_test/test_graph_view_signals.py
+++ b/src/tracksdata/graph/_test/test_graph_view_signals.py
@@ -27,8 +27,9 @@ def test_view_node_signals_fire_with_consistent_state(graph_backend: BaseGraph) 
     observations: list = []
 
     def make_slot(source: str, signal: str):
-        def slot(node_id: int, *_args) -> None:
-            observations.append((source, signal, node_id, graph_backend.has_node(node_id), view.has_node(node_id)))
+        def slot(node_ids: list[int], *_args) -> None:
+            for node_id in node_ids:
+                observations.append((source, signal, node_id, graph_backend.has_node(node_id), view.has_node(node_id)))
 
         return slot
 
@@ -67,8 +68,9 @@ def test_view_update_node_attrs_signal_fires_with_consistent_value(graph_backend
         return df.filter(pl.col(DEFAULT_ATTR_KEYS.NODE_ID) == nid)["x"].item()
 
     def make_slot(source: str):
-        def slot(nid: int, _old: dict, _new: dict) -> None:
-            observations.append((source, nid, attr_value(graph_backend, nid), attr_value(view, nid)))
+        def slot(node_ids: list[int], _old: list[dict], _new: list[dict]) -> None:
+            for nid in node_ids:
+                observations.append((source, nid, attr_value(graph_backend, nid), attr_value(view, nid)))
 
         return slot
 

--- a/src/tracksdata/graph/_test/test_subgraph.py
+++ b/src/tracksdata/graph/_test/test_subgraph.py
@@ -473,6 +473,43 @@ def test_subgraph_add_node(graph_backend: BaseGraph) -> None:
         assert attributes["label"].to_list()[0] == "NEW"
 
 
+def test_subgraph_bulk_add_nodes_emits_batched_node_added_callbacks(graph_backend: BaseGraph) -> None:
+    graph_with_data = create_test_graph(graph_backend, use_subgraph=False)
+    subgraph = graph_with_data.filter(node_ids=graph_with_data._test_nodes[:2]).subgraph()  # type: ignore
+
+    root_calls: list[tuple[object, object]] = []
+    subgraph_calls: list[tuple[object, object]] = []
+    graph_with_data.node_added.connect(lambda node_ids, attrs: root_calls.append((node_ids, attrs)))
+    subgraph.node_added.connect(lambda node_ids, attrs: subgraph_calls.append((node_ids, attrs)))
+
+    nodes = [
+        {"t": 10, "x": 10.0, "y": 10.0, "label": "A"},
+        {"t": 11, "x": 11.0, "y": 11.0, "label": "B"},
+    ]
+    node_ids = subgraph.bulk_add_nodes(nodes)
+
+    assert len(root_calls) == 1
+    assert len(subgraph_calls) == 1
+    assert root_calls[0] == (node_ids, nodes)
+    assert subgraph_calls[0] == (node_ids, nodes)
+
+
+def test_subgraph_update_node_attrs_emits_batched_node_updated_callback(graph_backend: BaseGraph) -> None:
+    graph_with_data = create_test_graph(graph_backend, use_subgraph=False)
+    subgraph = graph_with_data.filter(node_ids=graph_with_data._test_nodes[:3]).subgraph()  # type: ignore
+    node_ids = graph_with_data._test_nodes[:2]  # type: ignore
+
+    calls: list[tuple[object, object, object]] = []
+    subgraph.node_updated.connect(lambda node_ids, old_attrs, new_attrs: calls.append((node_ids, old_attrs, new_attrs)))
+
+    subgraph.update_node_attrs(node_ids=node_ids, attrs={"x": [10.0, 20.0]})
+
+    assert len(calls) == 1
+    assert calls[0][0] == node_ids
+    assert [attrs["x"] for attrs in calls[0][1]] == [0.0, 1.0]
+    assert [attrs["x"] for attrs in calls[0][2]] == [10.0, 20.0]
+
+
 def test_subgraph_add_edge(graph_backend: BaseGraph) -> None:
     """Test adding edges to a subgraph."""
     graph_with_data = create_test_graph(graph_backend, use_subgraph=False)
@@ -1337,3 +1374,40 @@ def test_edge_list(graph_backend: BaseGraph, use_subgraph: bool) -> None:
         )
     )
     assert edge_list == expected_edge_list
+
+
+def test_subgraph_bulk_remove_nodes(graph_backend: BaseGraph) -> None:
+    """bulk_remove_nodes on a view drops from view+root and cleans edge mappings."""
+    graph_with_data = create_test_graph(graph_backend, use_subgraph=False)
+    original_nodes = graph_with_data._test_nodes  # type: ignore
+
+    view = graph_with_data.filter().subgraph()
+
+    to_remove = [original_nodes[1], original_nodes[2]]
+    view.bulk_remove_nodes(to_remove)
+
+    remaining = set(original_nodes) - set(to_remove)
+    assert set(view.node_ids()) == remaining
+    assert set(graph_with_data.node_ids()) == remaining
+    # Edges incident to removed nodes must be gone from both layers.
+    view_edges = set(view.edge_ids())
+    root_edges = set(graph_with_data.edge_ids())
+    assert view_edges == root_edges
+
+
+def test_subgraph_bulk_remove_edges(graph_backend: BaseGraph) -> None:
+    """bulk_remove_edges on a view drops from view+root, nodes untouched."""
+    graph_with_data = create_test_graph(graph_backend, use_subgraph=False)
+    original_nodes = graph_with_data._test_nodes  # type: ignore
+    original_edges = graph_with_data._test_edges  # type: ignore
+
+    view = graph_with_data.filter().subgraph()
+
+    to_remove = original_edges[:2]
+    view.bulk_remove_edges(to_remove)
+
+    remaining = set(original_edges) - set(to_remove)
+    assert set(view.edge_ids()) == remaining
+    assert set(graph_with_data.edge_ids()) == remaining
+    assert set(view.node_ids()) == set(original_nodes)
+    assert set(graph_with_data.node_ids()) == set(original_nodes)

--- a/src/tracksdata/graph/_test/test_subgraph.py
+++ b/src/tracksdata/graph/_test/test_subgraph.py
@@ -1413,6 +1413,8 @@ def test_subgraph_bulk_remove_edges(graph_backend: BaseGraph) -> None:
     assert set(graph_with_data.edge_ids()) == remaining
     assert set(view.node_ids()) == set(original_nodes)
     assert set(graph_with_data.node_ids()) == set(original_nodes)
+
+
 def _build_chain_graph(graph: SQLGraph, n_nodes: int) -> list[int]:
     node_ids: list[int] = []
     for t in range(n_nodes):

--- a/src/tracksdata/graph/filters/_spatial_filter.py
+++ b/src/tracksdata/graph/filters/_spatial_filter.py
@@ -6,6 +6,7 @@ import polars as pl
 
 from tracksdata.constants import DEFAULT_ATTR_KEYS
 from tracksdata.utils._logging import LOG
+from tracksdata.utils._signal import iter_node_added_events, iter_node_updated_events
 
 if TYPE_CHECKING:
     from tracksdata.graph._base_graph import BaseGraph
@@ -205,24 +206,25 @@ class SpatialFilter:
 
     def _add_node(
         self,
-        node_id: int,
-        new_attrs: dict[str, Any],
+        node_id: int | list[int],
+        new_attrs: dict[str, Any] | list[dict[str, Any]],
     ) -> None:
         from spatial_graph import PointRTree
 
-        if self._df_filter._node_rtree is None:
-            self._df_filter._node_rtree = PointRTree(
-                item_dtype="int64",
-                coord_dtype="float32",
-                dims=len(self._attr_keys),
-            )
-            self._df_filter._ndims = len(self._attr_keys)
+        for event_node_id, event_attrs in iter_node_added_events(node_id, new_attrs):
+            if self._df_filter._node_rtree is None:
+                self._df_filter._node_rtree = PointRTree(
+                    item_dtype="int64",
+                    coord_dtype="float32",
+                    dims=len(self._attr_keys),
+                )
+                self._df_filter._ndims = len(self._attr_keys)
 
-        positions = self._attrs_to_point(new_attrs)
-        self._df_filter._node_rtree.insert_point_items(
-            np.atleast_1d(node_id).astype(np.int64),
-            positions,
-        )
+            positions = self._attrs_to_point(event_attrs)
+            self._df_filter._node_rtree.insert_point_items(
+                np.atleast_1d(event_node_id).astype(np.int64),
+                positions,
+            )
 
     def _remove_node(
         self,
@@ -241,12 +243,13 @@ class SpatialFilter:
 
     def _update_node(
         self,
-        node_id: int,
-        old_attrs: dict[str, Any],
-        new_attrs: dict[str, Any],
+        node_id: int | list[int],
+        old_attrs: dict[str, Any] | list[dict[str, Any]],
+        new_attrs: dict[str, Any] | list[dict[str, Any]],
     ) -> None:
-        self._remove_node(node_id, old_attrs=old_attrs)
-        self._add_node(node_id, new_attrs=new_attrs)
+        for event_node_id, event_old_attrs, event_new_attrs in iter_node_updated_events(node_id, old_attrs, new_attrs):
+            self._remove_node(event_node_id, old_attrs=event_old_attrs)
+            self._add_node(event_node_id, new_attrs=event_new_attrs)
 
 
 class BBoxSpatialFilter:
@@ -414,8 +417,8 @@ class BBoxSpatialFilter:
 
     def _add_node(
         self,
-        node_id: int,
-        new_attrs: dict[str, Any],
+        node_id: int | list[int],
+        new_attrs: dict[str, Any] | list[dict[str, Any]],
     ) -> None:
         """
         Add a node to the spatial filter.
@@ -429,29 +432,30 @@ class BBoxSpatialFilter:
         """
         from spatial_graph import PointRTree
 
-        if self._node_rtree is None:
-            bbox = new_attrs[self._bbox_attr_key]
-            if len(bbox) % 2 != 0:
-                raise ValueError(f"Bounding box coordinates must have even number of dimensions, got {len(bbox)}")
-            num_dims = len(bbox) // 2
-            if self._frame_attr_key is None:
-                self._ndims = num_dims
-            else:
-                self._ndims = num_dims + 1  # +1 for the frame dimension
+        for event_node_id, event_attrs in iter_node_added_events(node_id, new_attrs):
+            if self._node_rtree is None:
+                bbox = event_attrs[self._bbox_attr_key]
+                if len(bbox) % 2 != 0:
+                    raise ValueError(f"Bounding box coordinates must have even number of dimensions, got {len(bbox)}")
+                num_dims = len(bbox) // 2
+                if self._frame_attr_key is None:
+                    self._ndims = num_dims
+                else:
+                    self._ndims = num_dims + 1  # +1 for the frame dimension
 
-            self._node_rtree = PointRTree(
-                item_dtype="int64",
-                coord_dtype="float32",
-                dims=self._ndims,
+                self._node_rtree = PointRTree(
+                    item_dtype="int64",
+                    coord_dtype="float32",
+                    dims=self._ndims,
+                )
+
+            positions_min, positions_max = self._attrs_to_bb_window(event_attrs)
+
+            self._node_rtree.insert_bb_items(
+                np.atleast_1d(event_node_id).astype(np.int64),
+                positions_min,
+                positions_max,
             )
-
-        positions_min, positions_max = self._attrs_to_bb_window(new_attrs)
-
-        self._node_rtree.insert_bb_items(
-            np.atleast_1d(node_id).astype(np.int64),
-            positions_min,
-            positions_max,
-        )
 
     def _remove_node(
         self,
@@ -481,12 +485,13 @@ class BBoxSpatialFilter:
 
     def _update_node(
         self,
-        node_id: int,
-        old_attrs: dict[str, Any],
-        new_attrs: dict[str, Any],
+        node_id: int | list[int],
+        old_attrs: dict[str, Any] | list[dict[str, Any]],
+        new_attrs: dict[str, Any] | list[dict[str, Any]],
     ) -> None:
-        self._remove_node(node_id, old_attrs=old_attrs)
-        self._add_node(node_id, new_attrs=new_attrs)
+        for event_node_id, event_old_attrs, event_new_attrs in iter_node_updated_events(node_id, old_attrs, new_attrs):
+            self._remove_node(event_node_id, old_attrs=event_old_attrs)
+            self._add_node(event_node_id, new_attrs=event_new_attrs)
 
     @staticmethod
     def _bboxes_to_array(bbox_series: pl.Series) -> np.ndarray:

--- a/src/tracksdata/graph/filters/_spatial_filter.py
+++ b/src/tracksdata/graph/filters/_spatial_filter.py
@@ -6,7 +6,6 @@ import polars as pl
 
 from tracksdata.constants import DEFAULT_ATTR_KEYS
 from tracksdata.utils._logging import LOG
-from tracksdata.utils._signal import iter_node_added_events, iter_node_updated_events
 
 if TYPE_CHECKING:
     from tracksdata.graph._base_graph import BaseGraph
@@ -206,12 +205,12 @@ class SpatialFilter:
 
     def _add_node(
         self,
-        node_id: int | list[int],
-        new_attrs: dict[str, Any] | list[dict[str, Any]],
+        node_ids: list[int],
+        new_attrs: list[dict[str, Any]],
     ) -> None:
         from spatial_graph import PointRTree
 
-        for event_node_id, event_attrs in iter_node_added_events(node_id, new_attrs):
+        for node_id, attrs in zip(node_ids, new_attrs, strict=True):
             if self._df_filter._node_rtree is None:
                 self._df_filter._node_rtree = PointRTree(
                     item_dtype="int64",
@@ -220,36 +219,36 @@ class SpatialFilter:
                 )
                 self._df_filter._ndims = len(self._attr_keys)
 
-            positions = self._attrs_to_point(event_attrs)
+            positions = self._attrs_to_point(attrs)
             self._df_filter._node_rtree.insert_point_items(
-                np.atleast_1d(event_node_id).astype(np.int64),
+                np.atleast_1d(node_id).astype(np.int64),
                 positions,
             )
 
     def _remove_node(
         self,
-        node_id: int,
-        old_attrs: dict[str, Any],
+        node_ids: list[int],
+        old_attrs: list[dict[str, Any]],
     ) -> None:
         # required by static type checking
         if self._df_filter._node_rtree is None:
             return
 
-        positions = self._attrs_to_point(old_attrs)
-        self._df_filter._node_rtree.delete_items(
-            np.atleast_1d(node_id).astype(np.int64),
-            positions,
-        )
+        for node_id, attrs in zip(node_ids, old_attrs, strict=True):
+            positions = self._attrs_to_point(attrs)
+            self._df_filter._node_rtree.delete_items(
+                np.atleast_1d(node_id).astype(np.int64),
+                positions,
+            )
 
     def _update_node(
         self,
-        node_id: int | list[int],
-        old_attrs: dict[str, Any] | list[dict[str, Any]],
-        new_attrs: dict[str, Any] | list[dict[str, Any]],
+        node_ids: list[int],
+        old_attrs: list[dict[str, Any]],
+        new_attrs: list[dict[str, Any]],
     ) -> None:
-        for event_node_id, event_old_attrs, event_new_attrs in iter_node_updated_events(node_id, old_attrs, new_attrs):
-            self._remove_node(event_node_id, old_attrs=event_old_attrs)
-            self._add_node(event_node_id, new_attrs=event_new_attrs)
+        self._remove_node(node_ids, old_attrs)
+        self._add_node(node_ids, new_attrs)
 
 
 class BBoxSpatialFilter:
@@ -417,24 +416,24 @@ class BBoxSpatialFilter:
 
     def _add_node(
         self,
-        node_id: int | list[int],
-        new_attrs: dict[str, Any] | list[dict[str, Any]],
+        node_ids: list[int],
+        new_attrs: list[dict[str, Any]],
     ) -> None:
         """
-        Add a node to the spatial filter.
+        Add nodes to the spatial filter.
 
         Parameters
         ----------
-        node_id : int
-            The ID of the node to add.
-        new_attrs : dict[str, Any]
+        node_ids : list[int]
+            The IDs of the nodes to add.
+        new_attrs : list[dict[str, Any]]
             Current node attributes to insert into the spatial index.
         """
         from spatial_graph import PointRTree
 
-        for event_node_id, event_attrs in iter_node_added_events(node_id, new_attrs):
+        for node_id, attrs in zip(node_ids, new_attrs, strict=True):
             if self._node_rtree is None:
-                bbox = event_attrs[self._bbox_attr_key]
+                bbox = attrs[self._bbox_attr_key]
                 if len(bbox) % 2 != 0:
                     raise ValueError(f"Bounding box coordinates must have even number of dimensions, got {len(bbox)}")
                 num_dims = len(bbox) // 2
@@ -449,49 +448,49 @@ class BBoxSpatialFilter:
                     dims=self._ndims,
                 )
 
-            positions_min, positions_max = self._attrs_to_bb_window(event_attrs)
+            positions_min, positions_max = self._attrs_to_bb_window(attrs)
 
             self._node_rtree.insert_bb_items(
-                np.atleast_1d(event_node_id).astype(np.int64),
+                np.atleast_1d(node_id).astype(np.int64),
                 positions_min,
                 positions_max,
             )
 
     def _remove_node(
         self,
-        node_id: int,
-        old_attrs: dict[str, Any],
+        node_ids: list[int],
+        old_attrs: list[dict[str, Any]],
     ) -> None:
         """
-        Remove a node from the spatial filter.
+        Remove nodes from the spatial filter.
 
         Parameters
         ----------
-        node_id : int
-            The ID of the node to remove.
-        old_attrs : dict[str, Any]
+        node_ids : list[int]
+            The IDs of the nodes to remove.
+        old_attrs : list[dict[str, Any]]
             Previous node attributes used to remove the exact indexed bbox.
         """
         if self._node_rtree is None:
             return
 
-        positions_min, positions_max = self._attrs_to_bb_window(old_attrs)
+        for node_id, attrs in zip(node_ids, old_attrs, strict=True):
+            positions_min, positions_max = self._attrs_to_bb_window(attrs)
 
-        self._node_rtree.delete_items(
-            np.atleast_1d(node_id).astype(np.int64),
-            positions_min,
-            positions_max,
-        )
+            self._node_rtree.delete_items(
+                np.atleast_1d(node_id).astype(np.int64),
+                positions_min,
+                positions_max,
+            )
 
     def _update_node(
         self,
-        node_id: int | list[int],
-        old_attrs: dict[str, Any] | list[dict[str, Any]],
-        new_attrs: dict[str, Any] | list[dict[str, Any]],
+        node_ids: list[int],
+        old_attrs: list[dict[str, Any]],
+        new_attrs: list[dict[str, Any]],
     ) -> None:
-        for event_node_id, event_old_attrs, event_new_attrs in iter_node_updated_events(node_id, old_attrs, new_attrs):
-            self._remove_node(event_node_id, old_attrs=event_old_attrs)
-            self._add_node(event_node_id, new_attrs=event_new_attrs)
+        self._remove_node(node_ids, old_attrs)
+        self._add_node(node_ids, new_attrs)
 
     @staticmethod
     def _bboxes_to_array(bbox_series: pl.Series) -> np.ndarray:

--- a/src/tracksdata/utils/_signal.py
+++ b/src/tracksdata/utils/_signal.py
@@ -1,4 +1,94 @@
+from collections.abc import Iterable, Iterator, Sequence
+from typing import Any
+
 from psygnal import Signal, SignalInstance
+
+
+def _is_batched(value: object) -> bool:
+    return isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray | dict)
+
+
+def reduce_node_added_events(
+    event_args: Iterable[tuple[int, dict[str, Any]]],
+) -> tuple[int | list[int], dict[str, Any] | list[dict[str, Any]]]:
+    events = list(event_args)
+    if len(events) == 1:
+        return events[0]
+
+    node_ids, attrs = zip(*events, strict=True)
+    return list(node_ids), list(attrs)
+
+
+def reduce_node_updated_events(
+    event_args: Iterable[tuple[int, dict[str, Any], dict[str, Any]]],
+) -> tuple[int | list[int], dict[str, Any] | list[dict[str, Any]], dict[str, Any] | list[dict[str, Any]]]:
+    events = list(event_args)
+    if len(events) == 1:
+        return events[0]
+
+    node_ids, old_attrs, new_attrs = zip(*events, strict=True)
+    return list(node_ids), list(old_attrs), list(new_attrs)
+
+
+def emit_node_added_events(
+    sig: Signal | SignalInstance,
+    event_args: Iterable[tuple[int, dict[str, Any]]],
+) -> None:
+    events = list(event_args)
+    if len(events) == 0 or not is_signal_on(sig):
+        return
+
+    with sig.paused(reduce_node_added_events):
+        for node_id, attrs in events:
+            sig.emit(node_id, attrs)
+
+
+def emit_node_updated_events(
+    sig: Signal | SignalInstance,
+    event_args: Iterable[tuple[int, dict[str, Any], dict[str, Any]]],
+) -> None:
+    events = list(event_args)
+    if len(events) == 0 or not is_signal_on(sig):
+        return
+
+    with sig.paused(reduce_node_updated_events):
+        for node_id, old_attrs, new_attrs in events:
+            sig.emit(node_id, old_attrs, new_attrs)
+
+
+def iter_node_added_events(
+    node_ids: int | Sequence[int],
+    attrs: dict[str, Any] | Sequence[dict[str, Any]],
+) -> Iterator[tuple[int, dict[str, Any]]]:
+    if _is_batched(node_ids):
+        if not _is_batched(attrs):
+            raise TypeError("Expected a sequence of node attributes for batched node_added events.")
+
+        yield from zip(node_ids, attrs, strict=True)
+        return
+
+    if _is_batched(attrs):
+        raise TypeError("Expected a single node attributes dict for node_added events.")
+
+    yield node_ids, attrs
+
+
+def iter_node_updated_events(
+    node_ids: int | Sequence[int],
+    old_attrs: dict[str, Any] | Sequence[dict[str, Any]],
+    new_attrs: dict[str, Any] | Sequence[dict[str, Any]],
+) -> Iterator[tuple[int, dict[str, Any], dict[str, Any]]]:
+    if _is_batched(node_ids):
+        if not _is_batched(old_attrs) or not _is_batched(new_attrs):
+            raise TypeError("Expected sequences of node attribute dicts for batched node_updated events.")
+
+        yield from zip(node_ids, old_attrs, new_attrs, strict=True)
+        return
+
+    if _is_batched(old_attrs) or _is_batched(new_attrs):
+        raise TypeError("Expected single node attribute dicts for node_updated events.")
+
+    yield node_ids, old_attrs, new_attrs
 
 
 def is_signal_on(sig: Signal | SignalInstance) -> bool:

--- a/src/tracksdata/utils/_signal.py
+++ b/src/tracksdata/utils/_signal.py
@@ -11,6 +11,24 @@ def _is_batched(value: object) -> bool:
 def reduce_node_added_events(
     event_args: Iterable[tuple[int, dict[str, Any]]],
 ) -> tuple[int | list[int], dict[str, Any] | list[dict[str, Any]]]:
+    """
+    Collapse a stream of ``node_added`` event args into a single batched event.
+
+    A single event is returned unchanged as ``(node_id, attrs)``; multiple events
+    are combined into ``(list_of_ids, list_of_attrs)``. Used as the reducer passed
+    to ``SignalInstance.paused`` so listeners receive one batched emission.
+
+    Parameters
+    ----------
+    event_args : Iterable[tuple[int, dict[str, Any]]]
+        The ``(node_id, attrs)`` pairs collected while the signal was paused.
+
+    Returns
+    -------
+    tuple[int | list[int], dict[str, Any] | list[dict[str, Any]]]
+        Either a single ``(node_id, attrs)`` event or the batched
+        ``(list_of_ids, list_of_attrs)`` form.
+    """
     events = list(event_args)
     if len(events) == 1:
         return events[0]
@@ -22,6 +40,23 @@ def reduce_node_added_events(
 def reduce_node_updated_events(
     event_args: Iterable[tuple[int, dict[str, Any], dict[str, Any]]],
 ) -> tuple[int | list[int], dict[str, Any] | list[dict[str, Any]], dict[str, Any] | list[dict[str, Any]]]:
+    """
+    Collapse a stream of ``node_updated`` event args into a single batched event.
+
+    A single event is returned unchanged as ``(node_id, old_attrs, new_attrs)``;
+    multiple events are combined into ``(list_of_ids, list_of_old, list_of_new)``.
+    Used as the reducer passed to ``SignalInstance.paused``.
+
+    Parameters
+    ----------
+    event_args : Iterable[tuple[int, dict[str, Any], dict[str, Any]]]
+        The ``(node_id, old_attrs, new_attrs)`` triples collected while paused.
+
+    Returns
+    -------
+    tuple[int | list[int], dict[str, Any] | list[dict[str, Any]], dict[str, Any] | list[dict[str, Any]]]
+        Either a single event or the batched list form.
+    """
     events = list(event_args)
     if len(events) == 1:
         return events[0]
@@ -34,6 +69,21 @@ def emit_node_added_events(
     sig: Signal | SignalInstance,
     event_args: Iterable[tuple[int, dict[str, Any]]],
 ) -> None:
+    """
+    Emit ``node_added`` events as a single batched emission.
+
+    The signal is paused and reduced via :func:`reduce_node_added_events`, so
+    connected slots receive one call: ``(node_id, attrs)`` for a single node or
+    ``(list_of_ids, list_of_attrs)`` for many. No-op if there are no events or
+    the signal has no active listeners.
+
+    Parameters
+    ----------
+    sig : Signal | SignalInstance
+        The ``node_added`` signal to emit on.
+    event_args : Iterable[tuple[int, dict[str, Any]]]
+        The ``(node_id, attrs)`` pairs to emit.
+    """
     events = list(event_args)
     if len(events) == 0 or not is_signal_on(sig):
         return
@@ -47,6 +97,21 @@ def emit_node_updated_events(
     sig: Signal | SignalInstance,
     event_args: Iterable[tuple[int, dict[str, Any], dict[str, Any]]],
 ) -> None:
+    """
+    Emit ``node_updated`` events as a single batched emission.
+
+    The signal is paused and reduced via :func:`reduce_node_updated_events`, so
+    connected slots receive one call: ``(node_id, old_attrs, new_attrs)`` for a
+    single node or the list form for many. No-op if there are no events or the
+    signal has no active listeners.
+
+    Parameters
+    ----------
+    sig : Signal | SignalInstance
+        The ``node_updated`` signal to emit on.
+    event_args : Iterable[tuple[int, dict[str, Any], dict[str, Any]]]
+        The ``(node_id, old_attrs, new_attrs)`` triples to emit.
+    """
     events = list(event_args)
     if len(events) == 0 or not is_signal_on(sig):
         return
@@ -56,10 +121,63 @@ def emit_node_updated_events(
             sig.emit(node_id, old_attrs, new_attrs)
 
 
+def emit_node_removed_events(
+    sig: Signal | SignalInstance,
+    event_args: Iterable[tuple[int, dict[str, Any]]],
+) -> None:
+    """
+    Emit one ``node_removed`` event per removed node.
+
+    Unlike :func:`emit_node_added_events` and :func:`emit_node_updated_events`,
+    removal events are emitted individually rather than reduced into a single
+    batched event: connected slots (e.g. spatial-filter and array invalidation)
+    expect one ``(node_id, old_attrs)`` call per node. This helper centralises
+    the per-node emission loop shared by the graph backends. No-op if the signal
+    has no active listeners.
+
+    Parameters
+    ----------
+    sig : Signal | SignalInstance
+        The ``node_removed`` signal to emit on.
+    event_args : Iterable[tuple[int, dict[str, Any]]]
+        The ``(node_id, old_attrs)`` pairs to emit, one emission each.
+    """
+    if not is_signal_on(sig):
+        return
+
+    for node_id, old_attrs in event_args:
+        sig.emit(node_id, old_attrs)
+
+
 def iter_node_added_events(
     node_ids: int | Sequence[int],
     attrs: dict[str, Any] | Sequence[dict[str, Any]],
 ) -> Iterator[tuple[int, dict[str, Any]]]:
+    """
+    Normalise possibly-batched ``node_added`` payloads into individual events.
+
+    Accepts either a single ``(node_id, attrs)`` or the batched
+    ``(list_of_ids, list_of_attrs)`` form produced by
+    :func:`reduce_node_added_events`, and yields one ``(node_id, attrs)`` pair per
+    node. This lets slots handle both single and batched emissions uniformly.
+
+    Parameters
+    ----------
+    node_ids : int | Sequence[int]
+        A single node id or a sequence of ids.
+    attrs : dict[str, Any] | Sequence[dict[str, Any]]
+        The matching attributes; a single dict or a sequence of dicts.
+
+    Yields
+    ------
+    tuple[int, dict[str, Any]]
+        One ``(node_id, attrs)`` pair per node.
+
+    Raises
+    ------
+    TypeError
+        If the batched-ness of ``node_ids`` and ``attrs`` disagree.
+    """
     if _is_batched(node_ids):
         if not _is_batched(attrs):
             raise TypeError("Expected a sequence of node attributes for batched node_added events.")
@@ -78,6 +196,32 @@ def iter_node_updated_events(
     old_attrs: dict[str, Any] | Sequence[dict[str, Any]],
     new_attrs: dict[str, Any] | Sequence[dict[str, Any]],
 ) -> Iterator[tuple[int, dict[str, Any], dict[str, Any]]]:
+    """
+    Normalise possibly-batched ``node_updated`` payloads into individual events.
+
+    Accepts either a single ``(node_id, old_attrs, new_attrs)`` or the batched
+    list form produced by :func:`reduce_node_updated_events`, and yields one
+    ``(node_id, old_attrs, new_attrs)`` triple per node.
+
+    Parameters
+    ----------
+    node_ids : int | Sequence[int]
+        A single node id or a sequence of ids.
+    old_attrs : dict[str, Any] | Sequence[dict[str, Any]]
+        The previous attributes; a single dict or a sequence of dicts.
+    new_attrs : dict[str, Any] | Sequence[dict[str, Any]]
+        The new attributes; a single dict or a sequence of dicts.
+
+    Yields
+    ------
+    tuple[int, dict[str, Any], dict[str, Any]]
+        One ``(node_id, old_attrs, new_attrs)`` triple per node.
+
+    Raises
+    ------
+    TypeError
+        If the batched-ness of ``node_ids``, ``old_attrs`` and ``new_attrs`` disagree.
+    """
     if _is_batched(node_ids):
         if not _is_batched(old_attrs) or not _is_batched(new_attrs):
             raise TypeError("Expected sequences of node attribute dicts for batched node_updated events.")

--- a/src/tracksdata/utils/_signal.py
+++ b/src/tracksdata/utils/_signal.py
@@ -1,68 +1,12 @@
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Iterable
 from typing import Any
 
 from psygnal import Signal, SignalInstance
 
 
-def _is_batched(value: object) -> bool:
-    return isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray | dict)
-
-
-def reduce_node_added_events(
-    event_args: Iterable[tuple[int, dict[str, Any]]],
-) -> tuple[int | list[int], dict[str, Any] | list[dict[str, Any]]]:
-    """
-    Collapse a stream of ``node_added`` event args into a single batched event.
-
-    A single event is returned unchanged as ``(node_id, attrs)``; multiple events
-    are combined into ``(list_of_ids, list_of_attrs)``. Used as the reducer passed
-    to ``SignalInstance.paused`` so listeners receive one batched emission.
-
-    Parameters
-    ----------
-    event_args : Iterable[tuple[int, dict[str, Any]]]
-        The ``(node_id, attrs)`` pairs collected while the signal was paused.
-
-    Returns
-    -------
-    tuple[int | list[int], dict[str, Any] | list[dict[str, Any]]]
-        Either a single ``(node_id, attrs)`` event or the batched
-        ``(list_of_ids, list_of_attrs)`` form.
-    """
-    events = list(event_args)
-    if len(events) == 1:
-        return events[0]
-
-    node_ids, attrs = zip(*events, strict=True)
-    return list(node_ids), list(attrs)
-
-
-def reduce_node_updated_events(
-    event_args: Iterable[tuple[int, dict[str, Any], dict[str, Any]]],
-) -> tuple[int | list[int], dict[str, Any] | list[dict[str, Any]], dict[str, Any] | list[dict[str, Any]]]:
-    """
-    Collapse a stream of ``node_updated`` event args into a single batched event.
-
-    A single event is returned unchanged as ``(node_id, old_attrs, new_attrs)``;
-    multiple events are combined into ``(list_of_ids, list_of_old, list_of_new)``.
-    Used as the reducer passed to ``SignalInstance.paused``.
-
-    Parameters
-    ----------
-    event_args : Iterable[tuple[int, dict[str, Any], dict[str, Any]]]
-        The ``(node_id, old_attrs, new_attrs)`` triples collected while paused.
-
-    Returns
-    -------
-    tuple[int | list[int], dict[str, Any] | list[dict[str, Any]], dict[str, Any] | list[dict[str, Any]]]
-        Either a single event or the batched list form.
-    """
-    events = list(event_args)
-    if len(events) == 1:
-        return events[0]
-
-    node_ids, old_attrs, new_attrs = zip(*events, strict=True)
-    return list(node_ids), list(old_attrs), list(new_attrs)
+def is_signal_on(sig: Signal | SignalInstance) -> bool:
+    """Check if a signal is connected and not blocked."""
+    return len(sig._slots) > 0 and not sig._is_blocked
 
 
 def emit_node_added_events(
@@ -70,12 +14,11 @@ def emit_node_added_events(
     event_args: Iterable[tuple[int, dict[str, Any]]],
 ) -> None:
     """
-    Emit ``node_added`` events as a single batched emission.
+    Emit a single batched ``node_added`` event.
 
-    The signal is paused and reduced via :func:`reduce_node_added_events`, so
-    connected slots receive one call: ``(node_id, attrs)`` for a single node or
-    ``(list_of_ids, list_of_attrs)`` for many. No-op if there are no events or
-    the signal has no active listeners.
+    Connected slots always receive one call ``(list_of_ids, list_of_attrs)``,
+    regardless of how many nodes were added. No-op if there are no events or the
+    signal has no active listeners.
 
     Parameters
     ----------
@@ -88,9 +31,8 @@ def emit_node_added_events(
     if len(events) == 0 or not is_signal_on(sig):
         return
 
-    with sig.paused(reduce_node_added_events):
-        for node_id, attrs in events:
-            sig.emit(node_id, attrs)
+    node_ids, attrs = zip(*events, strict=True)
+    sig.emit(list(node_ids), list(attrs))
 
 
 def emit_node_updated_events(
@@ -98,12 +40,11 @@ def emit_node_updated_events(
     event_args: Iterable[tuple[int, dict[str, Any], dict[str, Any]]],
 ) -> None:
     """
-    Emit ``node_updated`` events as a single batched emission.
+    Emit a single batched ``node_updated`` event.
 
-    The signal is paused and reduced via :func:`reduce_node_updated_events`, so
-    connected slots receive one call: ``(node_id, old_attrs, new_attrs)`` for a
-    single node or the list form for many. No-op if there are no events or the
-    signal has no active listeners.
+    Connected slots always receive one call
+    ``(list_of_ids, list_of_old_attrs, list_of_new_attrs)``. No-op if there are
+    no events or the signal has no active listeners.
 
     Parameters
     ----------
@@ -116,9 +57,8 @@ def emit_node_updated_events(
     if len(events) == 0 or not is_signal_on(sig):
         return
 
-    with sig.paused(reduce_node_updated_events):
-        for node_id, old_attrs, new_attrs in events:
-            sig.emit(node_id, old_attrs, new_attrs)
+    node_ids, old_attrs, new_attrs = zip(*events, strict=True)
+    sig.emit(list(node_ids), list(old_attrs), list(new_attrs))
 
 
 def emit_node_removed_events(
@@ -126,115 +66,22 @@ def emit_node_removed_events(
     event_args: Iterable[tuple[int, dict[str, Any]]],
 ) -> None:
     """
-    Emit one ``node_removed`` event per removed node.
+    Emit a single batched ``node_removed`` event.
 
-    Unlike :func:`emit_node_added_events` and :func:`emit_node_updated_events`,
-    removal events are emitted individually rather than reduced into a single
-    batched event: connected slots (e.g. spatial-filter and array invalidation)
-    expect one ``(node_id, old_attrs)`` call per node. This helper centralises
-    the per-node emission loop shared by the graph backends. No-op if the signal
-    has no active listeners.
+    Connected slots always receive one call ``(list_of_ids, list_of_attrs)``,
+    regardless of how many nodes were removed. No-op if there are no events or
+    the signal has no active listeners.
 
     Parameters
     ----------
     sig : Signal | SignalInstance
         The ``node_removed`` signal to emit on.
     event_args : Iterable[tuple[int, dict[str, Any]]]
-        The ``(node_id, old_attrs)`` pairs to emit, one emission each.
+        The ``(node_id, old_attrs)`` pairs to emit.
     """
-    if not is_signal_on(sig):
+    events = list(event_args)
+    if len(events) == 0 or not is_signal_on(sig):
         return
 
-    for node_id, old_attrs in event_args:
-        sig.emit(node_id, old_attrs)
-
-
-def iter_node_added_events(
-    node_ids: int | Sequence[int],
-    attrs: dict[str, Any] | Sequence[dict[str, Any]],
-) -> Iterator[tuple[int, dict[str, Any]]]:
-    """
-    Normalise possibly-batched ``node_added`` payloads into individual events.
-
-    Accepts either a single ``(node_id, attrs)`` or the batched
-    ``(list_of_ids, list_of_attrs)`` form produced by
-    :func:`reduce_node_added_events`, and yields one ``(node_id, attrs)`` pair per
-    node. This lets slots handle both single and batched emissions uniformly.
-
-    Parameters
-    ----------
-    node_ids : int | Sequence[int]
-        A single node id or a sequence of ids.
-    attrs : dict[str, Any] | Sequence[dict[str, Any]]
-        The matching attributes; a single dict or a sequence of dicts.
-
-    Yields
-    ------
-    tuple[int, dict[str, Any]]
-        One ``(node_id, attrs)`` pair per node.
-
-    Raises
-    ------
-    TypeError
-        If the batched-ness of ``node_ids`` and ``attrs`` disagree.
-    """
-    if _is_batched(node_ids):
-        if not _is_batched(attrs):
-            raise TypeError("Expected a sequence of node attributes for batched node_added events.")
-
-        yield from zip(node_ids, attrs, strict=True)
-        return
-
-    if _is_batched(attrs):
-        raise TypeError("Expected a single node attributes dict for node_added events.")
-
-    yield node_ids, attrs
-
-
-def iter_node_updated_events(
-    node_ids: int | Sequence[int],
-    old_attrs: dict[str, Any] | Sequence[dict[str, Any]],
-    new_attrs: dict[str, Any] | Sequence[dict[str, Any]],
-) -> Iterator[tuple[int, dict[str, Any], dict[str, Any]]]:
-    """
-    Normalise possibly-batched ``node_updated`` payloads into individual events.
-
-    Accepts either a single ``(node_id, old_attrs, new_attrs)`` or the batched
-    list form produced by :func:`reduce_node_updated_events`, and yields one
-    ``(node_id, old_attrs, new_attrs)`` triple per node.
-
-    Parameters
-    ----------
-    node_ids : int | Sequence[int]
-        A single node id or a sequence of ids.
-    old_attrs : dict[str, Any] | Sequence[dict[str, Any]]
-        The previous attributes; a single dict or a sequence of dicts.
-    new_attrs : dict[str, Any] | Sequence[dict[str, Any]]
-        The new attributes; a single dict or a sequence of dicts.
-
-    Yields
-    ------
-    tuple[int, dict[str, Any], dict[str, Any]]
-        One ``(node_id, old_attrs, new_attrs)`` triple per node.
-
-    Raises
-    ------
-    TypeError
-        If the batched-ness of ``node_ids``, ``old_attrs`` and ``new_attrs`` disagree.
-    """
-    if _is_batched(node_ids):
-        if not _is_batched(old_attrs) or not _is_batched(new_attrs):
-            raise TypeError("Expected sequences of node attribute dicts for batched node_updated events.")
-
-        yield from zip(node_ids, old_attrs, new_attrs, strict=True)
-        return
-
-    if _is_batched(old_attrs) or _is_batched(new_attrs):
-        raise TypeError("Expected single node attribute dicts for node_updated events.")
-
-    yield node_ids, old_attrs, new_attrs
-
-
-def is_signal_on(sig: Signal | SignalInstance) -> bool:
-    """Check if a signal is connected and not blocked."""
-    return len(sig._slots) > 0 and not sig._is_blocked
+    node_ids, attrs = zip(*events, strict=True)
+    sig.emit(list(node_ids), list(attrs))


### PR DESCRIPTION
# Human summary

- Adds `batch_remove_*`
- Dropping duplicate codes by calling `bulk_add_...` inside `add_...`
- Batch handling of events; replaces #270  

# Copilot Summary

This pull request introduces bulk mutation operations and refactors node and edge addition/removal logic across the graph array and graph view classes. The changes improve efficiency, ensure atomic validation, and unify signal emission for both single and bulk operations. The most important updates are summarized below.

### Bulk mutation API additions

* Added `bulk_remove_nodes` and `bulk_remove_edges` methods to `BaseGraph`, `RustWorkXGraph`, and `GraphView`, enabling efficient removal of multiple nodes or edges at once with atomic validation and proper signal emission. [[1]](diffhunk://#diff-64e3286da4f8363c7957dd77d994e5ac66035910293ec9fd9dd4e0accb25d150R258-R289) [[2]](diffhunk://#diff-64e3286da4f8363c7957dd77d994e5ac66035910293ec9fd9dd4e0accb25d150R349-R380) [[3]](diffhunk://#diff-2524b6adc5e6ad6d90dd1b7bd20f8c012ecd382cf61c33a12e4d57c3c65cf3dbR491-R545) [[4]](diffhunk://#diff-2524b6adc5e6ad6d90dd1b7bd20f8c012ecd382cf61c33a12e4d57c3c65cf3dbR632-R665) [[5]](diffhunk://#diff-27571334684f43542e61947ffc945b35daae1e3461014efd94accda55e5ca7e6L567-R673)
* Introduced low-level local mutation helpers (`_bulk_add_nodes_local`, `_bulk_remove_nodes_local`, `_bulk_add_edges_local`, `_bulk_remove_edges_local`) in `RustWorkXGraph` to centralize and optimize node/edge manipulation logic.

### Signal emission and event handling improvements

* Refactored signal emission for node addition and update to use new utility functions (`emit_node_added_events`, `emit_node_updated_events`), ensuring consistent and efficient signal handling for both single and bulk operations. [[1]](diffhunk://#diff-2524b6adc5e6ad6d90dd1b7bd20f8c012ecd382cf61c33a12e4d57c3c65cf3dbL15-R19) [[2]](diffhunk://#diff-27571334684f43542e61947ffc945b35daae1e3461014efd94accda55e5ca7e6L19-R23) [[3]](diffhunk://#diff-2524b6adc5e6ad6d90dd1b7bd20f8c012ecd382cf61c33a12e4d57c3c65cf3dbR414-R427) [[4]](diffhunk://#diff-2524b6adc5e6ad6d90dd1b7bd20f8c012ecd382cf61c33a12e4d57c3c65cf3dbL750-R844) [[5]](diffhunk://#diff-27571334684f43542e61947ffc945b35daae1e3461014efd94accda55e5ca7e6L539-R623)
* Updated the `GraphArray` event handlers to support bulk node add/update events by iterating over event sequences, improving compatibility with the new bulk APIs. [[1]](diffhunk://#diff-28287673dc69395cff4eb04d797379dfd0e4d3cb4e4834fbf9a389e32ec47922R13) [[2]](diffhunk://#diff-28287673dc69395cff4eb04d797379dfd0e4d3cb4e4834fbf9a389e32ec47922L418-R439)

### Codebase and API consistency

* Refactored single-node add/remove methods to internally use the new bulk primitives, reducing code duplication and ensuring consistent behavior. [[1]](diffhunk://#diff-27571334684f43542e61947ffc945b35daae1e3461014efd94accda55e5ca7e6L504-R595) [[2]](diffhunk://#diff-27571334684f43542e61947ffc945b35daae1e3461014efd94accda55e5ca7e6L567-R673) [[3]](diffhunk://#diff-2524b6adc5e6ad6d90dd1b7bd20f8c012ecd382cf61c33a12e4d57c3c65cf3dbL393-R398) [[4]](diffhunk://#diff-2524b6adc5e6ad6d90dd1b7bd20f8c012ecd382cf61c33a12e4d57c3c65cf3dbL465-R467)
* Improved error handling in ID mapping logic to ensure user-facing errors are consistent between single and bulk operations.