### PR TITLE
Ensure minimal number of GraphArrayView invalidation calls

### DIFF
--- a/src/tracksdata/array/_graph_array.py
+++ b/src/tracksdata/array/_graph_array.py
@@ -399,12 +399,15 @@ class GraphArrayView(BaseReadOnlyArray):
         that time is invalidated. This is distinct from a bbox that lies outside the
         array volume, which invalidates nothing.
         """
+        if hasattr(time_values, "to_list"):
+            time_values = time_values.to_list()
+
         for time_value, bbox in zip(time_values, bboxes, strict=True):
             try:
-                time = int(np.asarray(time_value).item())
+                time = int(time_value)
             except (TypeError, ValueError) as e:
                 raise ValueError(
-                    f"Time attribute value must be a scalar integer, got {time_value} of type {type(time_value)}"
+                    f"Time attribute value must be a scalar integer, got {time_value!r} of type {type(time_value)}"
                 ) from e
             if not (0 <= time < self.original_shape[0]):
                 continue

--- a/src/tracksdata/array/_graph_array.py
+++ b/src/tracksdata/array/_graph_array.py
@@ -451,13 +451,30 @@ class GraphArrayView(BaseReadOnlyArray):
             old_bbox = old_attr.get(DEFAULT_ATTR_KEYS.BBOX)
             new_bbox = new_attr.get(DEFAULT_ATTR_KEYS.BBOX)
 
-            bbox_changed = old_t != new_t or not np.array_equal(old_bbox, new_bbox)
+            moved = old_t != new_t or not np.array_equal(old_bbox, new_bbox)
 
-            if bbox_changed:
+            if moved:
+                # Node relocated: clear the stale region and paint the new one.
                 time_values.extend((old_t, new_t))
                 bboxes.extend((old_bbox, new_bbox))
-            elif old_attr.get(self._attr_key) != new_attr.get(self._attr_key):
+            elif old_attr.get(self._attr_key) != new_attr.get(self._attr_key) or self._mask_changed(old_attr, new_attr):
                 time_values.append(new_t)
                 bboxes.append(new_bbox)
 
         self._invalidate_bbox(time_values, bboxes)
+
+    @staticmethod
+    def _mask_changed(old_attr: dict, new_attr: dict) -> bool:
+        """
+        Whether the painted output changed while the bbox stayed in place.
+
+        The rendered region depends on the displayed attribute value and the mask
+        pixels, so a mask swap with an unchanged bbox still requires invalidation.
+        """
+        old_mask = old_attr.get(DEFAULT_ATTR_KEYS.MASK)
+        new_mask = new_attr.get(DEFAULT_ATTR_KEYS.MASK)
+        if old_mask is None and new_mask is None:
+            return False
+        elif old_mask is None or new_mask is None:
+            return True
+        return old_mask != new_mask

--- a/src/tracksdata/array/_graph_array.py
+++ b/src/tracksdata/array/_graph_array.py
@@ -425,5 +425,15 @@ class GraphArrayView(BaseReadOnlyArray):
 
     def _on_node_updated(self, node_id: int, old_attrs: dict, new_attrs: dict) -> None:
         del node_id
-        self._invalidate_from_attrs(old_attrs)
-        self._invalidate_from_attrs(new_attrs)
+        old_t = old_attrs.get(DEFAULT_ATTR_KEYS.T)
+        new_t = new_attrs.get(DEFAULT_ATTR_KEYS.T)
+        old_bbox = old_attrs.get(DEFAULT_ATTR_KEYS.BBOX)
+        new_bbox = new_attrs.get(DEFAULT_ATTR_KEYS.BBOX)
+
+        bbox_changed = old_t != new_t or not np.array_equal(old_bbox, new_bbox)
+
+        if bbox_changed:
+            self._invalidate_from_attrs(old_attrs)
+            self._invalidate_from_attrs(new_attrs)
+        elif old_attrs.get(self._attr_key) != new_attrs.get(self._attr_key):
+            self._invalidate_from_attrs(new_attrs)

--- a/src/tracksdata/array/_graph_array.py
+++ b/src/tracksdata/array/_graph_array.py
@@ -395,9 +395,10 @@ class GraphArrayView(BaseReadOnlyArray):
 
         ``time_values`` and ``bboxes`` are parallel sequences; each ``(time, bbox)``
         pair is clipped to the array volume and the matching cache region is dropped.
-        A ``None`` bbox means the node's location is unknown, so the whole volume for
-        that time is invalidated. This is distinct from a bbox that lies outside the
-        array volume, which invalidates nothing.
+        A bbox that lies outside the array volume invalidates nothing.
+
+        A ``GraphArrayView`` requires every node to carry a ``bbox`` attribute, so a
+        ``None`` bbox is a programming error and raises ``ValueError``.
         """
         if hasattr(time_values, "to_list"):
             time_values = time_values.to_list()
@@ -413,9 +414,10 @@ class GraphArrayView(BaseReadOnlyArray):
                 continue
 
             if bbox is None:
-                # Unknown location: conservatively invalidate the whole volume for this time.
-                self._cache.invalidate(time=time)
-                continue
+                raise ValueError(
+                    f"Node at time {time} is missing a '{DEFAULT_ATTR_KEYS.BBOX}' attribute. "
+                    "A GraphArrayView requires every node to have a bbox."
+                )
 
             slices = self._bbox_to_slices(bbox)
             if slices is not None:

--- a/src/tracksdata/array/_graph_array.py
+++ b/src/tracksdata/array/_graph_array.py
@@ -389,20 +389,34 @@ class GraphArrayView(BaseReadOnlyArray):
 
         return tuple(slice(int(s), int(e)) for s, e in zip(start, stop, strict=True))
 
-    def _invalidate_bbox(self, time_value: Any, bbox: Any) -> None:
-        """Invalidate the cache region covered by the given time and bbox."""
-        try:
-            time = int(np.asarray(time_value).item())
-        except (TypeError, ValueError) as e:
-            raise ValueError(
-                f"Time attribute value must be a scalar integer, got {time_value} of type {type(time_value)}"
-            ) from e
-        if not (0 <= time < self.original_shape[0]):
-            return
+    def _invalidate_bbox(self, time_values: Sequence[Any], bboxes: Sequence[np.ndarray | None]) -> None:
+        """
+        Invalidate the cache regions covered by the given times and bboxes.
 
-        slices = self._bbox_to_slices(bbox)
-        if slices is not None:
-            self._cache.invalidate(time=time, volume_slicing=slices)
+        ``time_values`` and ``bboxes`` are parallel sequences; each ``(time, bbox)``
+        pair is clipped to the array volume and the matching cache region is dropped.
+        A ``None`` bbox means the node's location is unknown, so the whole volume for
+        that time is invalidated. This is distinct from a bbox that lies outside the
+        array volume, which invalidates nothing.
+        """
+        for time_value, bbox in zip(time_values, bboxes, strict=True):
+            try:
+                time = int(np.asarray(time_value).item())
+            except (TypeError, ValueError) as e:
+                raise ValueError(
+                    f"Time attribute value must be a scalar integer, got {time_value} of type {type(time_value)}"
+                ) from e
+            if not (0 <= time < self.original_shape[0]):
+                continue
+
+            if bbox is None:
+                # Unknown location: conservatively invalidate the whole volume for this time.
+                self._cache.invalidate(time=time)
+                continue
+
+            slices = self._bbox_to_slices(bbox)
+            if slices is not None:
+                self._cache.invalidate(time=time, volume_slicing=slices)
 
     def _on_node_added(
         self,
@@ -410,13 +424,17 @@ class GraphArrayView(BaseReadOnlyArray):
         new_attrs: list[dict],
     ) -> None:
         del node_ids
-        for attrs in new_attrs:
-            self._invalidate_bbox(attrs[DEFAULT_ATTR_KEYS.T], attrs[DEFAULT_ATTR_KEYS.BBOX])
+        self._invalidate_bbox(
+            [attrs[DEFAULT_ATTR_KEYS.T] for attrs in new_attrs],
+            [attrs.get(DEFAULT_ATTR_KEYS.BBOX) for attrs in new_attrs],
+        )
 
     def _on_node_removed(self, node_ids: list[int], old_attrs: list[dict]) -> None:
         del node_ids
-        for attrs in old_attrs:
-            self._invalidate_bbox(attrs[DEFAULT_ATTR_KEYS.T], attrs[DEFAULT_ATTR_KEYS.BBOX])
+        self._invalidate_bbox(
+            [attrs[DEFAULT_ATTR_KEYS.T] for attrs in old_attrs],
+            [attrs.get(DEFAULT_ATTR_KEYS.BBOX) for attrs in old_attrs],
+        )
 
     def _on_node_updated(
         self,
@@ -425,16 +443,21 @@ class GraphArrayView(BaseReadOnlyArray):
         new_attrs: list[dict],
     ) -> None:
         del node_ids
+        time_values: list[Any] = []
+        bboxes: list[Any] = []
         for old_attr, new_attr in zip(old_attrs, new_attrs, strict=True):
             old_t = old_attr[DEFAULT_ATTR_KEYS.T]
             new_t = new_attr[DEFAULT_ATTR_KEYS.T]
-            old_bbox = old_attr[DEFAULT_ATTR_KEYS.BBOX]
-            new_bbox = new_attr[DEFAULT_ATTR_KEYS.BBOX]
+            old_bbox = old_attr.get(DEFAULT_ATTR_KEYS.BBOX)
+            new_bbox = new_attr.get(DEFAULT_ATTR_KEYS.BBOX)
 
             bbox_changed = old_t != new_t or not np.array_equal(old_bbox, new_bbox)
 
             if bbox_changed:
-                self._invalidate_bbox(old_t, old_bbox)
-                self._invalidate_bbox(new_t, new_bbox)
+                time_values.extend((old_t, new_t))
+                bboxes.extend((old_bbox, new_bbox))
             elif old_attr.get(self._attr_key) != new_attr.get(self._attr_key):
-                self._invalidate_bbox(new_t, new_bbox)
+                time_values.append(new_t)
+                bboxes.append(new_bbox)
+
+        self._invalidate_bbox(time_values, bboxes)

--- a/src/tracksdata/array/_graph_array.py
+++ b/src/tracksdata/array/_graph_array.py
@@ -389,19 +389,8 @@ class GraphArrayView(BaseReadOnlyArray):
 
         return tuple(slice(int(s), int(e)) for s, e in zip(start, stop, strict=True))
 
-    def _invalidate_from_attrs(self, attrs: dict) -> None:
-        """
-        Invalidate cache region touched by node attributes.
-
-        Falls back to larger invalidation windows when metadata is incomplete.
-        """
-
-        time_value = attrs.get(DEFAULT_ATTR_KEYS.T)
-        if time_value is None:
-            raise ValueError(f"Node attributes must contain '{DEFAULT_ATTR_KEYS.T}' key for cache invalidation.")
-        if DEFAULT_ATTR_KEYS.BBOX not in attrs:
-            raise ValueError(f"Node attributes must contain '{DEFAULT_ATTR_KEYS.BBOX}' key for cache invalidation.")
-
+    def _invalidate_bbox(self, time_value: Any, bbox: Any) -> None:
+        """Invalidate the cache region covered by the given time and bbox."""
         try:
             time = int(np.asarray(time_value).item())
         except (TypeError, ValueError) as e:
@@ -411,29 +400,29 @@ class GraphArrayView(BaseReadOnlyArray):
         if not (0 <= time < self.original_shape[0]):
             return
 
-        slices = self._bbox_to_slices(attrs[DEFAULT_ATTR_KEYS.BBOX])
+        slices = self._bbox_to_slices(bbox)
         if slices is not None:
             self._cache.invalidate(time=time, volume_slicing=slices)
 
     def _on_node_added(self, node_id: int, new_attrs: dict) -> None:
         del node_id
-        self._invalidate_from_attrs(new_attrs)
+        self._invalidate_bbox(new_attrs[DEFAULT_ATTR_KEYS.T], new_attrs[DEFAULT_ATTR_KEYS.BBOX])
 
     def _on_node_removed(self, node_id: int, old_attrs: dict) -> None:
         del node_id
-        self._invalidate_from_attrs(old_attrs)
+        self._invalidate_bbox(old_attrs[DEFAULT_ATTR_KEYS.T], old_attrs[DEFAULT_ATTR_KEYS.BBOX])
 
     def _on_node_updated(self, node_id: int, old_attrs: dict, new_attrs: dict) -> None:
         del node_id
-        old_t = old_attrs.get(DEFAULT_ATTR_KEYS.T)
-        new_t = new_attrs.get(DEFAULT_ATTR_KEYS.T)
-        old_bbox = old_attrs.get(DEFAULT_ATTR_KEYS.BBOX)
-        new_bbox = new_attrs.get(DEFAULT_ATTR_KEYS.BBOX)
+        old_t = old_attrs[DEFAULT_ATTR_KEYS.T]
+        new_t = new_attrs[DEFAULT_ATTR_KEYS.T]
+        old_bbox = old_attrs[DEFAULT_ATTR_KEYS.BBOX]
+        new_bbox = new_attrs[DEFAULT_ATTR_KEYS.BBOX]
 
         bbox_changed = old_t != new_t or not np.array_equal(old_bbox, new_bbox)
 
         if bbox_changed:
-            self._invalidate_from_attrs(old_attrs)
-            self._invalidate_from_attrs(new_attrs)
+            self._invalidate_bbox(old_t, old_bbox)
+            self._invalidate_bbox(new_t, new_bbox)
         elif old_attrs.get(self._attr_key) != new_attrs.get(self._attr_key):
-            self._invalidate_from_attrs(new_attrs)
+            self._invalidate_bbox(new_t, new_bbox)

--- a/src/tracksdata/array/_test/test_graph_array.py
+++ b/src/tracksdata/array/_test/test_graph_array.py
@@ -490,8 +490,9 @@ def test_graph_array_view_invalidates_once_when_attr_key_changes_but_bbox_unchan
             attrs={"label": [7]},
             node_ids=[node_id],
         )
-        # bbox unchanged, but the displayed attribute changed — invalidate exactly once
-        assert mock_invalidate.call_count == 1
+        # bbox unchanged, but the displayed attribute changed — invalidate exactly one region
+        n_regions = sum(len(call.args[0]) for call in mock_invalidate.call_args_list)
+        assert n_regions == 1
 
     # The affected chunk must be invalidated
     expected_ready = np.ones((2, 2), dtype=bool)
@@ -533,7 +534,8 @@ def test_graph_array_view_invalidates_twice_when_attr_key_and_bbox_change(graph_
             node_ids=[node_id],
         )
         # bbox changed — must invalidate both old and new regions
-        assert mock_invalidate.call_count == 2
+        n_regions = sum(len(call.args[0]) for call in mock_invalidate.call_args_list)
+        assert n_regions == 2
 
     expected_ready = np.ones((2, 2), dtype=bool)
     expected_ready[0, 0] = False
@@ -571,8 +573,9 @@ def test_graph_array_view_no_invalidation_when_unrelated_attr_changes(graph_back
             attrs={"score": [0.9]},
             node_ids=[node_id],
         )
-        # Neither bbox nor the displayed attribute changed — no invalidation at all
-        assert mock_invalidate.call_count == 0
+        # Neither bbox nor the displayed attribute changed — no region invalidated
+        n_regions = sum(len(call.args[0]) for call in mock_invalidate.call_args_list)
+        assert n_regions == 0
 
     np.testing.assert_array_equal(
         array_view._cache._store[0].ready,
@@ -614,3 +617,28 @@ def test_graph_array_view_invalidates_chunk_on_remove(graph_backend: BaseGraph) 
     output = np.asarray(array_view[0])
     assert output[1, 1] == 1
     assert output[5, 5] == 0
+
+
+def test_graph_array_view_invalidates_whole_volume_when_bbox_missing(graph_backend: BaseGraph) -> None:
+    """A node event without a bbox key has an unknown location, so the whole time volume is invalidated."""
+    _add_graph_array_node_attrs(graph_backend)
+
+    mask = _make_square_mask(1, 1)
+    graph_backend.add_node(
+        {
+            DEFAULT_ATTR_KEYS.T: 0,
+            "label": 1,
+            DEFAULT_ATTR_KEYS.MASK: mask,
+            DEFAULT_ATTR_KEYS.BBOX: mask.bbox,
+        }
+    )
+
+    array_view = GraphArrayView(graph=graph_backend, shape=(2, 8, 8), attr_key="label", chunk_shape=(4, 4))
+    _ = np.asarray(array_view[0])
+    np.testing.assert_array_equal(array_view._cache._store[0].ready, np.ones((2, 2), dtype=bool))
+
+    # Emit a node-added event whose attrs lack a bbox key: location unknown.
+    array_view._on_node_added([999], [{DEFAULT_ATTR_KEYS.T: 0, "label": 5}])
+
+    # The entire volume for time 0 must be invalidated.
+    np.testing.assert_array_equal(array_view._cache._store[0].ready, np.zeros((2, 2), dtype=bool))

--- a/src/tracksdata/array/_test/test_graph_array.py
+++ b/src/tracksdata/array/_test/test_graph_array.py
@@ -619,8 +619,8 @@ def test_graph_array_view_invalidates_chunk_on_remove(graph_backend: BaseGraph) 
     assert output[5, 5] == 0
 
 
-def test_graph_array_view_invalidates_whole_volume_when_bbox_missing(graph_backend: BaseGraph) -> None:
-    """A node event without a bbox key has an unknown location, so the whole time volume is invalidated."""
+def test_graph_array_view_raises_when_bbox_missing(graph_backend: BaseGraph) -> None:
+    """A GraphArrayView requires every node to have a bbox, so a missing bbox must raise."""
     _add_graph_array_node_attrs(graph_backend)
 
     mask = _make_square_mask(1, 1)
@@ -637,11 +637,9 @@ def test_graph_array_view_invalidates_whole_volume_when_bbox_missing(graph_backe
     _ = np.asarray(array_view[0])
     np.testing.assert_array_equal(array_view._cache._store[0].ready, np.ones((2, 2), dtype=bool))
 
-    # Emit a node-added event whose attrs lack a bbox key: location unknown.
-    array_view._on_node_added([999], [{DEFAULT_ATTR_KEYS.T: 0, "label": 5}])
-
-    # The entire volume for time 0 must be invalidated.
-    np.testing.assert_array_equal(array_view._cache._store[0].ready, np.zeros((2, 2), dtype=bool))
+    # An event whose attrs lack a bbox key is a programming error.
+    with pytest.raises(ValueError, match=DEFAULT_ATTR_KEYS.BBOX):
+        array_view._on_node_added([999], [{DEFAULT_ATTR_KEYS.T: 0, "label": 5}])
 
 
 def test_graph_array_view_invalidates_once_when_mask_changes_but_bbox_unchanged(graph_backend: BaseGraph) -> None:

--- a/src/tracksdata/array/_test/test_graph_array.py
+++ b/src/tracksdata/array/_test/test_graph_array.py
@@ -484,8 +484,8 @@ def test_graph_array_view_invalidates_once_when_attr_key_changes_but_bbox_unchan
     _ = np.asarray(array_view[0])
     np.testing.assert_array_equal(array_view._cache._store[0].ready, np.ones((2, 2), dtype=bool))
 
-    mock_invalidate = MagicMock(wraps=array_view._invalidate_from_attrs)
-    with patch.object(array_view, "_invalidate_from_attrs", mock_invalidate):
+    mock_invalidate = MagicMock(wraps=array_view._invalidate_bbox)
+    with patch.object(array_view, "_invalidate_bbox", mock_invalidate):
         graph_backend.update_node_attrs(
             attrs={"label": [7]},
             node_ids=[node_id],
@@ -522,8 +522,8 @@ def test_graph_array_view_invalidates_twice_when_attr_key_and_bbox_change(graph_
     np.testing.assert_array_equal(array_view._cache._store[0].ready, np.ones((2, 2), dtype=bool))
 
     moved_mask = _make_square_mask(5, 5)
-    mock_invalidate = MagicMock(wraps=array_view._invalidate_from_attrs)
-    with patch.object(array_view, "_invalidate_from_attrs", mock_invalidate):
+    mock_invalidate = MagicMock(wraps=array_view._invalidate_bbox)
+    with patch.object(array_view, "_invalidate_bbox", mock_invalidate):
         graph_backend.update_node_attrs(
             attrs={
                 "label": [7],
@@ -565,8 +565,8 @@ def test_graph_array_view_no_invalidation_when_unrelated_attr_changes(graph_back
     _ = np.asarray(array_view[0])
     np.testing.assert_array_equal(array_view._cache._store[0].ready, np.ones((2, 2), dtype=bool))
 
-    mock_invalidate = MagicMock(wraps=array_view._invalidate_from_attrs)
-    with patch.object(array_view, "_invalidate_from_attrs", mock_invalidate):
+    mock_invalidate = MagicMock(wraps=array_view._invalidate_bbox)
+    with patch.object(array_view, "_invalidate_bbox", mock_invalidate):
         graph_backend.update_node_attrs(
             attrs={"score": [0.9]},
             node_ids=[node_id],

--- a/src/tracksdata/array/_test/test_graph_array.py
+++ b/src/tracksdata/array/_test/test_graph_array.py
@@ -642,3 +642,78 @@ def test_graph_array_view_invalidates_whole_volume_when_bbox_missing(graph_backe
 
     # The entire volume for time 0 must be invalidated.
     np.testing.assert_array_equal(array_view._cache._store[0].ready, np.zeros((2, 2), dtype=bool))
+
+
+def test_graph_array_view_invalidates_once_when_mask_changes_but_bbox_unchanged(graph_backend: BaseGraph) -> None:
+    """Swapping the mask pixels without moving the bbox must invalidate the region exactly once."""
+    _add_graph_array_node_attrs(graph_backend)
+
+    mask = _make_square_mask(1, 1)  # bbox [1, 1, 3, 3], fully filled
+    node_id = graph_backend.add_node(
+        {
+            DEFAULT_ATTR_KEYS.T: 0,
+            "label": 1,
+            DEFAULT_ATTR_KEYS.MASK: mask,
+            DEFAULT_ATTR_KEYS.BBOX: mask.bbox,
+        }
+    )
+
+    array_view = GraphArrayView(graph=graph_backend, shape=(2, 8, 8), attr_key="label", chunk_shape=(4, 4))
+    _ = np.asarray(array_view[0])
+    np.testing.assert_array_equal(array_view._cache._store[0].ready, np.ones((2, 2), dtype=bool))
+
+    # Same bbox [1, 1, 3, 3], but only the diagonal pixels are set.
+    new_mask = Mask(np.array([[True, False], [False, True]], dtype=bool), bbox=np.array([1, 1, 3, 3]))
+    mock_invalidate = MagicMock(wraps=array_view._invalidate_bbox)
+    with patch.object(array_view, "_invalidate_bbox", mock_invalidate):
+        graph_backend.update_node_attrs(
+            attrs={DEFAULT_ATTR_KEYS.MASK: [new_mask]},
+            node_ids=[node_id],
+        )
+        # bbox and label unchanged, but the mask pixels changed — invalidate exactly one region
+        n_regions = sum(len(call.args[0]) for call in mock_invalidate.call_args_list)
+        assert n_regions == 1
+
+    expected_ready = np.ones((2, 2), dtype=bool)
+    expected_ready[0, 0] = False
+    np.testing.assert_array_equal(array_view._cache._store[0].ready, expected_ready)
+
+    # After recomputation only the diagonal pixels carry the label.
+    output = np.asarray(array_view[0])
+    assert output[1, 1] == 1
+    assert output[2, 2] == 1
+    assert output[1, 2] == 0
+    assert output[2, 1] == 0
+
+
+def test_graph_array_view_no_invalidation_when_mask_unchanged(graph_backend: BaseGraph) -> None:
+    """Re-supplying an identical mask (same bbox and pixels) must not invalidate anything."""
+    _add_graph_array_node_attrs(graph_backend)
+
+    mask = _make_square_mask(1, 1)
+    node_id = graph_backend.add_node(
+        {
+            DEFAULT_ATTR_KEYS.T: 0,
+            "label": 1,
+            DEFAULT_ATTR_KEYS.MASK: mask,
+            DEFAULT_ATTR_KEYS.BBOX: mask.bbox,
+        }
+    )
+
+    array_view = GraphArrayView(graph=graph_backend, shape=(2, 8, 8), attr_key="label", chunk_shape=(4, 4))
+    _ = np.asarray(array_view[0])
+    np.testing.assert_array_equal(array_view._cache._store[0].ready, np.ones((2, 2), dtype=bool))
+
+    # A fresh Mask object with identical bbox and pixels: no rendered change.
+    same_mask = Mask(np.ones((2, 2), dtype=bool), bbox=np.array([1, 1, 3, 3]))
+    mock_invalidate = MagicMock(wraps=array_view._invalidate_bbox)
+    with patch.object(array_view, "_invalidate_bbox", mock_invalidate):
+        graph_backend.update_node_attrs(
+            attrs={DEFAULT_ATTR_KEYS.MASK: [same_mask]},
+            node_ids=[node_id],
+        )
+        # Nothing affecting the rendered output changed — no region invalidated
+        n_regions = sum(len(call.args[0]) for call in mock_invalidate.call_args_list)
+        assert n_regions == 0
+
+    np.testing.assert_array_equal(array_view._cache._store[0].ready, np.ones((2, 2), dtype=bool))

--- a/src/tracksdata/array/_test/test_graph_array.py
+++ b/src/tracksdata/array/_test/test_graph_array.py
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import polars as pl
@@ -461,6 +462,122 @@ def test_graph_array_view_invalidates_old_and_new_chunks_on_update(graph_backend
     output = np.asarray(array_view[0])
     assert output[1, 1] == 0
     assert output[5, 5] == 7
+
+
+def test_graph_array_view_invalidates_once_when_attr_key_changes_but_bbox_unchanged(
+    graph_backend: BaseGraph,
+) -> None:
+    """Updating the displayed attr_key (label) without moving the node should invalidate the region exactly once."""
+    _add_graph_array_node_attrs(graph_backend)
+
+    mask = _make_square_mask(1, 1)
+    node_id = graph_backend.add_node(
+        {
+            DEFAULT_ATTR_KEYS.T: 0,
+            "label": 1,
+            DEFAULT_ATTR_KEYS.MASK: mask,
+            DEFAULT_ATTR_KEYS.BBOX: mask.bbox,
+        }
+    )
+
+    array_view = GraphArrayView(graph=graph_backend, shape=(2, 8, 8), attr_key="label", chunk_shape=(4, 4))
+    _ = np.asarray(array_view[0])
+    np.testing.assert_array_equal(array_view._cache._store[0].ready, np.ones((2, 2), dtype=bool))
+
+    mock_invalidate = MagicMock(wraps=array_view._invalidate_from_attrs)
+    with patch.object(array_view, "_invalidate_from_attrs", mock_invalidate):
+        graph_backend.update_node_attrs(
+            attrs={"label": [7]},
+            node_ids=[node_id],
+        )
+        # bbox unchanged, but the displayed attribute changed — invalidate exactly once
+        assert mock_invalidate.call_count == 1
+
+    # The affected chunk must be invalidated
+    expected_ready = np.ones((2, 2), dtype=bool)
+    expected_ready[0, 0] = False
+    np.testing.assert_array_equal(array_view._cache._store[0].ready, expected_ready)
+
+    # After recomputation, the new value should be painted
+    output = np.asarray(array_view[0])
+    assert output[1, 1] == 7
+
+
+def test_graph_array_view_invalidates_twice_when_attr_key_and_bbox_change(graph_backend: BaseGraph) -> None:
+    """Updating both the displayed attr_key and the bbox should invalidate old and new regions."""
+    _add_graph_array_node_attrs(graph_backend)
+
+    mask = _make_square_mask(1, 1)
+    node_id = graph_backend.add_node(
+        {
+            DEFAULT_ATTR_KEYS.T: 0,
+            "label": 1,
+            DEFAULT_ATTR_KEYS.MASK: mask,
+            DEFAULT_ATTR_KEYS.BBOX: mask.bbox,
+        }
+    )
+
+    array_view = GraphArrayView(graph=graph_backend, shape=(2, 8, 8), attr_key="label", chunk_shape=(4, 4))
+    _ = np.asarray(array_view[0])
+    np.testing.assert_array_equal(array_view._cache._store[0].ready, np.ones((2, 2), dtype=bool))
+
+    moved_mask = _make_square_mask(5, 5)
+    mock_invalidate = MagicMock(wraps=array_view._invalidate_from_attrs)
+    with patch.object(array_view, "_invalidate_from_attrs", mock_invalidate):
+        graph_backend.update_node_attrs(
+            attrs={
+                "label": [7],
+                DEFAULT_ATTR_KEYS.MASK: [moved_mask],
+                DEFAULT_ATTR_KEYS.BBOX: [moved_mask.bbox],
+            },
+            node_ids=[node_id],
+        )
+        # bbox changed — must invalidate both old and new regions
+        assert mock_invalidate.call_count == 2
+
+    expected_ready = np.ones((2, 2), dtype=bool)
+    expected_ready[0, 0] = False
+    expected_ready[1, 1] = False
+    np.testing.assert_array_equal(array_view._cache._store[0].ready, expected_ready)
+
+    output = np.asarray(array_view[0])
+    assert output[1, 1] == 0
+    assert output[5, 5] == 7
+
+
+def test_graph_array_view_no_invalidation_when_unrelated_attr_changes(graph_backend: BaseGraph) -> None:
+    """Updating an attribute the view doesn't display should not invalidate any chunks."""
+    _add_graph_array_node_attrs(graph_backend)
+    graph_backend.add_node_attr_key("score", dtype=pl.Float64)
+
+    mask = _make_square_mask(1, 1)
+    node_id = graph_backend.add_node(
+        {
+            DEFAULT_ATTR_KEYS.T: 0,
+            "label": 1,
+            "score": 0.5,
+            DEFAULT_ATTR_KEYS.MASK: mask,
+            DEFAULT_ATTR_KEYS.BBOX: mask.bbox,
+        }
+    )
+
+    array_view = GraphArrayView(graph=graph_backend, shape=(2, 8, 8), attr_key="label", chunk_shape=(4, 4))
+    _ = np.asarray(array_view[0])
+    np.testing.assert_array_equal(array_view._cache._store[0].ready, np.ones((2, 2), dtype=bool))
+
+    mock_invalidate = MagicMock(wraps=array_view._invalidate_from_attrs)
+    with patch.object(array_view, "_invalidate_from_attrs", mock_invalidate):
+        graph_backend.update_node_attrs(
+            attrs={"score": [0.9]},
+            node_ids=[node_id],
+        )
+        # Neither bbox nor the displayed attribute changed — no invalidation at all
+        assert mock_invalidate.call_count == 0
+
+    np.testing.assert_array_equal(
+        array_view._cache._store[0].ready,
+        np.ones((2, 2), dtype=bool),
+    )
 
 
 def test_graph_array_view_invalidates_chunk_on_remove(graph_backend: BaseGraph) -> None:

--- a/src/tracksdata/graph/_sql_graph.py
+++ b/src/tracksdata/graph/_sql_graph.py
@@ -2110,15 +2110,6 @@ class SQLGraph(BaseGraph):
             for node_id in updated_node_ids:
                 self.node_updated.emit(node_id, old_attrs_by_id[node_id], new_attrs_by_id[node_id])
 
-            new_df = self.filter(node_ids=updated_node_ids).node_attrs(
-                attr_keys=[DEFAULT_ATTR_KEYS.NODE_ID, *attr_keys]
-            )
-            new_attrs_by_id = new_df.rows_by_key(
-                key=DEFAULT_ATTR_KEYS.NODE_ID, named=True, unique=True, include_key=True
-            )
-            for node_id in updated_node_ids:
-                self.node_updated.emit(node_id, old_attrs_by_id[node_id], new_attrs_by_id[node_id])
-
     def update_edge_attrs(
         self,
         *,


### PR DESCRIPTION
Currently, GraphArrayView invalidates the old and new bboxes in the cache any time any node attribute is updated, including totally unrelated ones.

Also, it appears that SQLGraph emits the signal that triggers this twice: https://github.com/royerlab/tracksdata/blob/13f9ba8f0a9376daaca5d388c7c979d8ca58f822/src/tracksdata/graph/_sql_graph.py#L2110-L2111 and https://github.com/royerlab/tracksdata/blob/13f9ba8f0a9376daaca5d388c7c979d8ca58f822/src/tracksdata/graph/_sql_graph.py#L2119-L2120

Every cache invalidation is expensive, and re-invaliding the same area multiple times resets any progress already made in loading.

This PR ensures the following behavior for all graph backends:
- If the spatial bbox and attr_key are unchanged, do not invalidate the cache
- If the spatial box is unchanged but the attr_key changes, invalidate the cache once
- If the spatial bbox is changed, invalidate the cache twice (old and new bboxes)