### PR TITLE
Unpin zarr, pin numcodecs per Python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,11 +51,12 @@ dependencies = [
   "geff>=1.1.3.1.1",
   "psygnal>=0.14.0",
   # zarr 2.x's util.py imports cbuffer_sizes/cbuffer_metainfo from
-  # numcodecs.blosc, which numcodecs >= 0.16 removed. On Python 3.10 the
-  # resolver is forced to numcodecs <= 0.13 (numcodecs >= 0.14 needs
-  # Python >= 3.11), so zarr 2.18 still imports there. On Python >= 3.11
-  # nothing prevents the broken pair, so require zarr >= 3 explicitly.
-  "zarr>=3; python_version >= '3.11'",
+  # numcodecs.blosc, which numcodecs >= 0.16 removed. Pin numcodecs per
+  # Python version (mirroring geff) instead of pinning zarr, so tracksdata
+  # remains co-installable with downstream tools still on zarr 2.x.
+  "numcodecs>=0.13",
+  "numcodecs>=0.13,<0.16; python_version > '3.10,<=3.11'", # TODO: remove pin once the 16 release is stable
+  "numcodecs>=0.15; python_version >= '3.13'", # TODO: remove pin once the 16 release is stable
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Closes #301.

The `zarr>=3; python_version >= '3.11'` pin from #289 blocks installing tracksdata next to tools still on zarr 2.x. The real constraint is numcodecs >= 0.16 dropping symbols that zarr 2.x's util.py imports at load time, so pin numcodecs by Python version (mirroring [geff](https://github.com/live-image-tracking-tools/geff/blob/35c8691fae11b3dda528a1c7ebb28afadde67d92/packages/geff/pyproject.toml#L34-L36)) and let zarr float.

Existing test suite covers the geff/zarr import paths.