### PR TITLE
prevent codecov failing on PRs from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         run: uv run pytest --cov=tracksdata --cov-report=xml src/tracksdata
 
     - name: Upload coverage to Codecov
-      if: matrix.python-version == '3.12'
+      if: matrix.python-version == '3.12' && github.event.pull_request.head.repo.full_name == github.repository
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
PRs/branches on forks (like #300) have failing tests, because the codecov secret is private and not shared with forks. 

This PR makes sure that codecov doesn't try to report when the branch is on a fork. 