### PR TITLE
Fix multiprocessing_apply crash on empty sequences with n_workers > 1

### DIFF
--- a/src/tracksdata/utils/_multiprocessing.py
+++ b/src/tracksdata/utils/_multiprocessing.py
@@ -52,7 +52,10 @@ def multiprocessing_apply(
     options = get_options()
     disable_tqdm = not options.show_progress
 
-    if length == 1:
+    if length == 0:
+        return
+
+    elif length == 1:
         # skipping iteration overhead
         yield func(sequence[0])
 

--- a/src/tracksdata/utils/_test/test_multiprocessing.py
+++ b/src/tracksdata/utils/_test/test_multiprocessing.py
@@ -1,0 +1,22 @@
+import pytest
+
+from tracksdata.options import options_context
+from tracksdata.utils._multiprocessing import multiprocessing_apply
+
+
+def _square(x: int) -> int:
+    return x * x
+
+
+@pytest.mark.parametrize("n_workers", [1, 2])
+def test_multiprocessing_apply_empty_sequence(n_workers: int) -> None:
+    """An empty sequence must be a no-op regardless of the worker count."""
+    with options_context(n_workers=n_workers):
+        assert list(multiprocessing_apply(_square, [], desc="empty")) == []
+
+
+@pytest.mark.parametrize("n_workers", [1, 2])
+def test_multiprocessing_apply_results(n_workers: int) -> None:
+    with options_context(n_workers=n_workers):
+        results = sorted(multiprocessing_apply(_square, [1, 2, 3], desc="squares"))
+    assert results == [1, 4, 9]


### PR DESCRIPTION
`multiprocessing_apply` reached `Pool(0)` for empty sequences when `n_workers > 1`, raising `ValueError`. Reachable from any operator on a graph without time points when parallelism is enabled.

Return early for empty input.

Added tests for empty and non-empty sequences with 1 and 2 workers.