### PR TITLE
store masks in geff as bool, not uint64

### DIFF
--- a/src/tracksdata/graph/_base_graph.py
+++ b/src/tracksdata/graph/_base_graph.py
@@ -1906,7 +1906,7 @@ class BaseGraph(abc.ABC):
                     dtype=(
                         polars_dtype_to_numpy_dtype(v.dtype, compatibility=True)
                         if k != DEFAULT_ATTR_KEYS.MASK
-                        else np.uint64
+                        else np.bool_
                     ),
                     varlength=k == DEFAULT_ATTR_KEYS.MASK,
                 )
@@ -1940,7 +1940,7 @@ class BaseGraph(abc.ABC):
 
         if DEFAULT_ATTR_KEYS.MASK in node_attrs.columns:
             node_dict[DEFAULT_ATTR_KEYS.MASK] = construct_var_len_props(
-                [mask.mask.astype(np.uint64) for mask in node_attrs[DEFAULT_ATTR_KEYS.MASK]]
+                [mask.mask.astype(bool) for mask in node_attrs[DEFAULT_ATTR_KEYS.MASK]]
             )
 
         edge_dict = {k: {"values": column_to_numpy(v), "missing": None} for k, v in edge_attrs.to_dict().items()}


### PR DESCRIPTION
In our original understanding, `geff` has the requirement that `variable length` attributes must be stored as `unit64`. 

However, there is nuance to this. A variable-length attribute has `values` (indices) and `data` (the actual data). Geff only enforced the `values` to be `unit64`, not the `data`! So it is perfectly fine for us to store `mask` as `bool`, as long as the `values` are still `unit64`. 

Saving the masks as `bool` saves us a lot of memory (64x). Not for the on-disc geff, because the zarr compression is the same for uint64/bool, but for loading and in-memory graphs, this is a huge win. 

This PR is a draft to see if it works.

Any ideas, @JoOkuma? 