### PR TITLE
fix add_edge_to_view leaving edge_id to -1 in SQL

### DIFF
--- a/src/tracksdata/graph/_graph_view.py
+++ b/src/tracksdata/graph/_graph_view.py
@@ -798,6 +798,11 @@ class GraphView(MappedGraphMixin, RustWorkXGraph):
                 if c in df.columns
             ]
             attrs = df.filter(pl.col(DEFAULT_ATTR_KEYS.EDGE_ID) == parent_edge_id).drop(drop_cols).rows(named=True)[0]
+            # A rustworkx-family root shares its payload, EDGE_ID included; other backends
+            # hand back a plain dict, so stamp the root edge id explicitly (as `bulk_add_edges`
+            # does). Otherwise the local edge keeps the -1 placeholder and disagrees with
+            # `_edge_map_to_root`, so reads by edge id find no row.
+            attrs[DEFAULT_ATTR_KEYS.EDGE_ID] = parent_edge_id
 
         local_edge_id = self.rx_graph.add_edge(
             self._map_to_local(source_id),

--- a/src/tracksdata/graph/_test/test_subgraph.py
+++ b/src/tracksdata/graph/_test/test_subgraph.py
@@ -1648,6 +1648,23 @@ def test_add_edge_to_view_basic(graph_backend: BaseGraph) -> None:
     assert row["weight"].item() == 0.5
 
 
+def test_add_edge_to_view_keeps_edge_id(graph_backend: BaseGraph) -> None:
+    """A revived edge's local row must carry the root edge id, so reads by id work."""
+    graph_backend.add_edge_attr_key("weight", pl.Float64)
+
+    n0 = graph_backend.add_node({"t": 0})
+    n1 = graph_backend.add_node({"t": 1})
+    root_edge_id = graph_backend.add_edge(n0, n1, {"weight": 1.5})
+
+    view = graph_backend.filter().subgraph()
+    view.remove_edge_from_view(n0, n1)
+    view.add_edge_to_view(n0, n1)
+
+    assert view.edge_id(n0, n1) == root_edge_id
+    assert view.edge_attrs(attr_keys=["weight"])[DEFAULT_ATTR_KEYS.EDGE_ID].to_list() == [root_edge_id]
+    assert view.edges[root_edge_id]["weight"] == 1.5
+
+
 def test_add_edge_to_view_validation(graph_backend: BaseGraph) -> None:
     """Bad inputs raise ValueError; sync=False raises RuntimeError."""
     graph_backend.add_node_attr_key("x", pl.Float64)


### PR DESCRIPTION
Fix: `add_edge_to_view` leaves the local `edge_id` as -1 on a SQL root

Reviving a soft-deleted edge into a view with `add_edge_to_view` left the view's local copy of the edge with `edge_id = -1` (the placeholder) when the root is a `SQLGraph`. The id map was updated correctly, so `view.edge_id(a, b)` returned the right root id while `view.edge_attrs()` still showed -1 for that row — the two disagreed, and any read of that edge's attributes *by edge id* hit zero rows.

### Reproduction

```python
import polars as pl
from tracksdata.graph import SQLGraph

g = SQLGraph(drivername="sqlite", database=":memory:")
g.add_edge_attr_key("weight", pl.Float64)
a = g.add_node({"t": 0})
b = g.add_node({"t": 1})
edge_id = g.add_edge(a, b, {"weight": 1.5})

view = g.filter().subgraph()
view.remove_edge_from_view(a, b)   # hide the edge in the view only
view.add_edge_to_view(a, b)        # bring it back

print(view.edge_id(a, b))                      # 1    -> id map is correct
print(view.edge_attrs()["edge_id"].to_list())  # [-1]  -> local row is wrong
print(view.edges[edge_id]["weight"])           # ValueError
```

```
ValueError: can only call '.item()' if the Series is of length 1, or an explicit
index is provided (Series is of length 0)
```

The root graph is fine throughout, and the in-memory backends are unaffected: there the view reuses the root's edge payload by reference, so the id comes along for free. `_add_edge_local` only breaks for a non-rx root, where it re-fetches the edge attrs, drops `edge_id`, and never stamps it back.

### Fix

Stamp the root edge id into the reconstructed payload in `_add_edge_local`, the same way `add_edge` and `bulk_add_edges` already do.

### Test

`test_add_edge_to_view_keeps_edge_id` — revive an edge into a view, then assert the id map, the `edge_attrs()` row, and a read by edge id all agree. Parametrized over all three backends; it failed on `SQLGraph` only before the fix.
