### PR TITLE
Add scale metadata attribute

### DIFF
--- a/src/tracksdata/array/_graph_array.py
+++ b/src/tracksdata/array/_graph_array.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from tracksdata.array._base_array import ArrayIndex, BaseReadOnlyArray
 from tracksdata.array._nd_chunk_cache import NDChunkCache
-from tracksdata.constants import DEFAULT_ATTR_KEYS
+from tracksdata.constants import DEFAULT_ATTR_KEYS, DEFAULT_METADATA_KEYS
 from tracksdata.graph._base_graph import BaseGraph
 from tracksdata.options import get_options
 from tracksdata.utils._dtypes import polars_dtype_to_numpy_dtype
@@ -23,7 +23,7 @@ def _validate_shape(
     """Helper function to validate the shape argument."""
     if shape is None:
         try:
-            shape = graph.metadata["shape"]
+            shape = graph.metadata[DEFAULT_METADATA_KEYS.SHAPE]
         except KeyError as e:
             raise KeyError(
                 f"`shape` is required to `{func_name}`. "

--- a/src/tracksdata/constants.py
+++ b/src/tracksdata/constants.py
@@ -72,3 +72,29 @@ class DefaultAttrKeys:
 
 
 DEFAULT_ATTR_KEYS = DefaultAttrKeys()
+
+
+class DefaultMetadataKeys:
+    """
+    This class defines the standard keys for `graph.metadata`, tracksdata's
+    key-value store for graph-level (as opposed to per-node/per-edge) information.
+
+    Using these constants instead of hardcoded strings helps prevent typos.
+
+    Attributes
+    ----------
+    SHAPE : str
+        Default key for the shape of the dense segmentation the graph was built
+        from, as ``(t, (z), y, x)``. Read by `GraphArrayView` and `to_ctc` when no
+        explicit ``shape`` is given.
+    SCALE : str
+        Default key for the physical voxel size of the dense segmentation, as
+        ``((z), y, x)``, i.e. without the time axis.
+    ```
+    """
+
+    SHAPE = "shape"
+    SCALE = "scale"
+
+
+DEFAULT_METADATA_KEYS = DefaultMetadataKeys()

--- a/src/tracksdata/graph/_base_graph.py
+++ b/src/tracksdata/graph/_base_graph.py
@@ -2055,21 +2055,23 @@ class BaseGraph(abc.ABC):
     def _is_private_metadata_key(cls, key: str) -> bool:
         return key.startswith(cls._PRIVATE_METADATA_PREFIX)
 
-    def _validate_metadata_key(self, key: str, *, is_public: bool) -> None:
+    @classmethod
+    def _validate_metadata_key(cls, key: str, *, is_public: bool) -> None:
         if not isinstance(key, str):
             raise TypeError(f"Metadata key must be a string. Got {type(key)}.")
-        is_private_key = self._is_private_metadata_key(key)
+        is_private_key = cls._is_private_metadata_key(key)
         if is_public and is_private_key:
             raise ValueError(f"Metadata key '{key}' is reserved for internal use.")
         if not is_public and not is_private_key:
             raise ValueError(
                 f"Metadata key '{key}' is not private. Private metadata keys must start with "
-                f"'{self._PRIVATE_METADATA_PREFIX}'."
+                f"'{cls._PRIVATE_METADATA_PREFIX}'."
             )
 
-    def _validate_metadata_keys(self, keys: Sequence[str], *, is_public: bool) -> None:
+    @classmethod
+    def _validate_metadata_keys(cls, keys: Sequence[str], *, is_public: bool) -> None:
         for key in keys:
-            self._validate_metadata_key(key, is_public=is_public)
+            cls._validate_metadata_key(key, is_public=is_public)
 
     def _set_metadata_with_validation(self, is_public: bool = True, **kwargs) -> None:
         self._validate_metadata_keys(kwargs.keys(), is_public=is_public)

--- a/src/tracksdata/io/__init__.py
+++ b/src/tracksdata/io/__init__.py
@@ -5,6 +5,8 @@ from tracksdata.io._geff import (
     convert_geff_prop_dtype,
     geff_prop_dtype,
     read_graph_metadata,
+    remove_graph_metadata,
+    write_graph_metadata,
 )
 
 __all__ = [
@@ -13,5 +15,7 @@ __all__ = [
     "from_ctc",
     "geff_prop_dtype",
     "read_graph_metadata",
+    "remove_graph_metadata",
     "to_ctc",
+    "write_graph_metadata",
 ]

--- a/src/tracksdata/io/__init__.py
+++ b/src/tracksdata/io/__init__.py
@@ -2,14 +2,15 @@
 
 from tracksdata.io._ctc import compressed_tracks_table, from_ctc, to_ctc
 from tracksdata.io._geff import (
+    append_graph_metadata,
     convert_geff_prop_dtype,
     geff_prop_dtype,
     read_graph_metadata,
     remove_graph_metadata,
-    write_graph_metadata,
 )
 
 __all__ = [
+    "append_graph_metadata",
     "compressed_tracks_table",
     "convert_geff_prop_dtype",
     "from_ctc",
@@ -17,5 +18,4 @@ __all__ = [
     "read_graph_metadata",
     "remove_graph_metadata",
     "to_ctc",
-    "write_graph_metadata",
 ]

--- a/src/tracksdata/io/_geff.py
+++ b/src/tracksdata/io/_geff.py
@@ -37,11 +37,11 @@ from tracksdata.graph._base_graph import BaseGraph
 from tracksdata.utils._logging import LOG
 
 __all__ = [
+    "append_graph_metadata",
     "convert_geff_prop_dtype",
     "geff_prop_dtype",
     "read_graph_metadata",
     "remove_graph_metadata",
-    "write_graph_metadata",
 ]
 
 _EXTRA_KEY = "tracksdata"
@@ -82,9 +82,9 @@ def read_graph_metadata(source: StoreLike | GeffMetadata) -> dict[str, Any]:
     return {k: v for k, v in metadata.items() if not BaseGraph._is_private_metadata_key(k)}
 
 
-def write_graph_metadata(store: StoreLike, **kwargs: Any) -> None:
+def append_graph_metadata(store: StoreLike, **kwargs: Any) -> None:
     """
-    Write tracksdata graph metadata into an existing geff store, without loading the graph.
+    Append tracksdata graph metadata into an existing geff store, without loading the graph.
 
     Counterpart to :func:`read_graph_metadata`. Merges ``kwargs`` into the store's
     existing `extra["tracksdata"]` entry, so previously written keys are preserved
@@ -101,7 +101,7 @@ def write_graph_metadata(store: StoreLike, **kwargs: Any) -> None:
     Examples
     --------
     ```python
-    write_graph_metadata("tracks.geff", shape=(5, 100, 100))
+    append_graph_metadata("tracks.geff", shape=(5, 100, 100))
     read_graph_metadata("tracks.geff")["shape"]  # [5, 100, 100]
     ```
     """

--- a/src/tracksdata/io/_geff.py
+++ b/src/tracksdata/io/_geff.py
@@ -36,7 +36,13 @@ from zarr.storage import StoreLike
 from tracksdata.graph._base_graph import BaseGraph
 from tracksdata.utils._logging import LOG
 
-__all__ = ["convert_geff_prop_dtype", "geff_prop_dtype", "read_graph_metadata"]
+__all__ = [
+    "convert_geff_prop_dtype",
+    "geff_prop_dtype",
+    "read_graph_metadata",
+    "remove_graph_metadata",
+    "write_graph_metadata",
+]
 
 _EXTRA_KEY = "tracksdata"
 
@@ -74,6 +80,69 @@ def read_graph_metadata(source: StoreLike | GeffMetadata) -> dict[str, Any]:
     metadata = source.extra.get(_EXTRA_KEY, {})
 
     return {k: v for k, v in metadata.items() if not BaseGraph._is_private_metadata_key(k)}
+
+
+def write_graph_metadata(store: StoreLike, **kwargs: Any) -> None:
+    """
+    Write tracksdata graph metadata into an existing geff store, without loading the graph.
+
+    Counterpart to :func:`read_graph_metadata`. Merges ``kwargs`` into the store's
+    existing `extra["tracksdata"]` entry, so previously written keys are preserved
+    unless overwritten. Private metadata keys (starting with
+    `BaseGraph._PRIVATE_METADATA_PREFIX`) are rejected, matching `graph.metadata`.
+
+    Parameters
+    ----------
+    store : StoreLike
+        The store or path of the geff dataset.
+    **kwargs : Any
+        The metadata entries to write, e.g. `shape=(5, 100, 100)`.
+
+    Examples
+    --------
+    ```python
+    write_graph_metadata("tracks.geff", shape=(5, 100, 100))
+    read_graph_metadata("tracks.geff")["shape"]  # [5, 100, 100]
+    ```
+    """
+    BaseGraph._validate_metadata_keys(kwargs.keys(), is_public=True)
+
+    metadata = GeffMetadata.read(store)
+    extra = dict(metadata.extra)
+    extra[_EXTRA_KEY] = {**extra.get(_EXTRA_KEY, {}), **kwargs}
+    metadata.extra = extra
+    metadata.write(store)
+
+
+def remove_graph_metadata(store: StoreLike, key: str) -> None:
+    """
+    Remove a tracksdata graph metadata entry from an existing geff store, without loading the graph.
+
+    Counterpart to :func:`read_graph_metadata`. A no-op if ``key`` is not present.
+
+    Parameters
+    ----------
+    store : StoreLike
+        The store or path of the geff dataset.
+    key : str
+        The metadata key to remove.
+
+    Examples
+    --------
+    ```python
+    remove_graph_metadata("tracks.geff", "shape")
+    "shape" in read_graph_metadata("tracks.geff")  # False
+    ```
+    """
+    BaseGraph._validate_metadata_key(key, is_public=True)
+
+    metadata = GeffMetadata.read(store)
+    extra = dict(metadata.extra)
+    tracksdata_extra = dict(extra.get(_EXTRA_KEY, {}))
+    tracksdata_extra.pop(key, None)
+    extra[_EXTRA_KEY] = tracksdata_extra
+    metadata.extra = extra
+    metadata.write(store)
 
 
 def geff_prop_dtype(

--- a/src/tracksdata/io/_test/test_geff_metadata.py
+++ b/src/tracksdata/io/_test/test_geff_metadata.py
@@ -7,9 +7,9 @@ from zarr.storage import MemoryStore
 
 from tracksdata.graph import RustWorkXGraph
 from tracksdata.io import (
+    append_graph_metadata,
     read_graph_metadata,
     remove_graph_metadata,
-    write_graph_metadata,
 )
 
 SHAPE = (5, 100, 100)
@@ -94,59 +94,59 @@ def test_read_graph_metadata_excludes_private_keys() -> None:
     assert read_graph_metadata(store) == {"shape": list(SHAPE)}
 
 
-def test_write_graph_metadata_from_path(tmp_path: Path) -> None:
-    """`write_graph_metadata` adds a new key without a graph object."""
+def test_append_graph_metadata_from_path(tmp_path: Path) -> None:
+    """`append_graph_metadata` adds a new key without a graph object."""
     graph = _make_graph()
     geff_path = tmp_path / "tracks.geff"
     graph.to_geff(geff_store=geff_path)
 
-    write_graph_metadata(geff_path, scale=(0.5, 0.2, 0.2))
+    append_graph_metadata(geff_path, scale=(0.5, 0.2, 0.2))
 
     assert read_graph_metadata(geff_path) == {"shape": list(SHAPE), "scale": [0.5, 0.2, 0.2]}
 
 
-def test_write_graph_metadata_merges_with_existing_keys() -> None:
+def test_append_graph_metadata_merges_with_existing_keys() -> None:
     """Writing one key does not clobber other previously written keys."""
     graph = _make_graph()
     store = MemoryStore()
     graph.to_geff(geff_store=store)
 
-    write_graph_metadata(store, scale=(0.5, 0.2, 0.2))
+    append_graph_metadata(store, scale=(0.5, 0.2, 0.2))
 
     assert read_graph_metadata(store) == {"shape": list(SHAPE), "scale": [0.5, 0.2, 0.2]}
 
 
-def test_write_graph_metadata_overwrites_existing_key() -> None:
+def test_append_graph_metadata_overwrites_existing_key() -> None:
     """Writing an existing key overwrites its value."""
     graph = _make_graph()
     store = MemoryStore()
     graph.to_geff(geff_store=store)
 
-    write_graph_metadata(store, shape=(1, 2, 3))
+    append_graph_metadata(store, shape=(1, 2, 3))
 
     assert read_graph_metadata(store) == {"shape": [1, 2, 3]}
 
 
-def test_write_graph_metadata_on_store_without_tracksdata_extras() -> None:
+def test_append_graph_metadata_on_store_without_tracksdata_extras() -> None:
     """Writing works on a geff that was not written by tracksdata."""
     store = MemoryStore()
     _minimal_geff_metadata().write(store)
 
-    write_graph_metadata(store, shape=(1, 2, 3))
+    append_graph_metadata(store, shape=(1, 2, 3))
 
     assert read_graph_metadata(store) == {"shape": [1, 2, 3]}
     # the caller's own namespace is untouched
     assert GeffMetadata.read(store).extra["downstream"] == {"hello": "world"}
 
 
-def test_write_graph_metadata_rejects_private_keys() -> None:
+def test_append_graph_metadata_rejects_private_keys() -> None:
     """Private metadata keys cannot be set through the public writer."""
     graph = _make_graph()
     store = MemoryStore()
     graph.to_geff(geff_store=store)
 
     with pytest.raises(ValueError, match="reserved for internal use"):
-        write_graph_metadata(store, __private_secret=42)
+        append_graph_metadata(store, __private_secret=42)
 
 
 def test_remove_graph_metadata_from_path(tmp_path: Path) -> None:

--- a/src/tracksdata/io/_test/test_geff_metadata.py
+++ b/src/tracksdata/io/_test/test_geff_metadata.py
@@ -1,11 +1,16 @@
 from pathlib import Path
 
 import polars as pl
+import pytest
 from geff_spec import Axis, GeffMetadata, PropMetadata
 from zarr.storage import MemoryStore
 
 from tracksdata.graph import RustWorkXGraph
-from tracksdata.io import read_graph_metadata
+from tracksdata.io import (
+    read_graph_metadata,
+    remove_graph_metadata,
+    write_graph_metadata,
+)
 
 SHAPE = (5, 100, 100)
 
@@ -87,3 +92,90 @@ def test_read_graph_metadata_excludes_private_keys() -> None:
 
     assert "__private_secret" in GeffMetadata.read(store).extra["tracksdata"]
     assert read_graph_metadata(store) == {"shape": list(SHAPE)}
+
+
+def test_write_graph_metadata_from_path(tmp_path: Path) -> None:
+    """`write_graph_metadata` adds a new key without a graph object."""
+    graph = _make_graph()
+    geff_path = tmp_path / "tracks.geff"
+    graph.to_geff(geff_store=geff_path)
+
+    write_graph_metadata(geff_path, scale=(0.5, 0.2, 0.2))
+
+    assert read_graph_metadata(geff_path) == {"shape": list(SHAPE), "scale": [0.5, 0.2, 0.2]}
+
+
+def test_write_graph_metadata_merges_with_existing_keys() -> None:
+    """Writing one key does not clobber other previously written keys."""
+    graph = _make_graph()
+    store = MemoryStore()
+    graph.to_geff(geff_store=store)
+
+    write_graph_metadata(store, scale=(0.5, 0.2, 0.2))
+
+    assert read_graph_metadata(store) == {"shape": list(SHAPE), "scale": [0.5, 0.2, 0.2]}
+
+
+def test_write_graph_metadata_overwrites_existing_key() -> None:
+    """Writing an existing key overwrites its value."""
+    graph = _make_graph()
+    store = MemoryStore()
+    graph.to_geff(geff_store=store)
+
+    write_graph_metadata(store, shape=(1, 2, 3))
+
+    assert read_graph_metadata(store) == {"shape": [1, 2, 3]}
+
+
+def test_write_graph_metadata_on_store_without_tracksdata_extras() -> None:
+    """Writing works on a geff that was not written by tracksdata."""
+    store = MemoryStore()
+    _minimal_geff_metadata().write(store)
+
+    write_graph_metadata(store, shape=(1, 2, 3))
+
+    assert read_graph_metadata(store) == {"shape": [1, 2, 3]}
+    # the caller's own namespace is untouched
+    assert GeffMetadata.read(store).extra["downstream"] == {"hello": "world"}
+
+
+def test_write_graph_metadata_rejects_private_keys() -> None:
+    """Private metadata keys cannot be set through the public writer."""
+    graph = _make_graph()
+    store = MemoryStore()
+    graph.to_geff(geff_store=store)
+
+    with pytest.raises(ValueError, match="reserved for internal use"):
+        write_graph_metadata(store, __private_secret=42)
+
+
+def test_remove_graph_metadata_from_path(tmp_path: Path) -> None:
+    """`remove_graph_metadata` removes a key without a graph object."""
+    graph = _make_graph()
+    geff_path = tmp_path / "tracks.geff"
+    graph.to_geff(geff_store=geff_path)
+
+    remove_graph_metadata(geff_path, "shape")
+
+    assert read_graph_metadata(geff_path) == {}
+
+
+def test_remove_graph_metadata_is_noop_if_missing() -> None:
+    """Removing a key that is not present does not raise."""
+    graph = _make_graph()
+    store = MemoryStore()
+    graph.to_geff(geff_store=store)
+
+    remove_graph_metadata(store, "does_not_exist")
+
+    assert read_graph_metadata(store) == {"shape": list(SHAPE)}
+
+
+def test_remove_graph_metadata_rejects_private_keys() -> None:
+    """Private metadata keys cannot be removed through the public remover."""
+    graph = _make_graph()
+    store = MemoryStore()
+    graph.to_geff(geff_store=store)
+
+    with pytest.raises(ValueError, match="reserved for internal use"):
+        remove_graph_metadata(store, "__private_secret")

--- a/src/tracksdata/nodes/_regionprops.py
+++ b/src/tracksdata/nodes/_regionprops.py
@@ -9,7 +9,7 @@ from polars.datatypes import numpy_char_code_to_dtype
 from skimage.measure._regionprops import RegionProperties, regionprops
 from typing_extensions import override
 
-from tracksdata.constants import DEFAULT_ATTR_KEYS
+from tracksdata.constants import DEFAULT_ATTR_KEYS, DEFAULT_METADATA_KEYS
 from tracksdata.graph._base_graph import BaseGraph
 from tracksdata.nodes._base_nodes import BaseNodesOperator
 from tracksdata.nodes._mask import Mask
@@ -202,6 +202,15 @@ class RegionPropsNodes(BaseNodesOperator):
             intensity-based properties. Must have the same shape as labels
             (excluding the label values).
 
+        Raises
+        ------
+        ValueError
+            If the graph already has a `scale` metadata entry that differs from
+            this operator's `spacing`. Region properties such as `perimeter` or
+            `axis_major_length` are computed using `spacing`, so a mismatch would
+            silently make the graph's `scale` metadata describe a different
+            resolution than the one used to compute them.
+
         Examples
         --------
         Add nodes from a single 2D labeled image:
@@ -229,8 +238,18 @@ class RegionPropsNodes(BaseNodesOperator):
         node_op.add_nodes(graph, labels=labels, t=0, intensity_image=fluorescence_image)
         ```
         """
-        if "shape" not in graph.metadata:
-            graph.metadata.update(shape=labels.shape)
+        if DEFAULT_METADATA_KEYS.SHAPE not in graph.metadata:
+            graph.metadata.update(**{DEFAULT_METADATA_KEYS.SHAPE: labels.shape})
+
+        if self._spacing is not None:
+            existing_scale = graph.metadata.get(DEFAULT_METADATA_KEYS.SCALE)
+            if existing_scale is None:
+                graph.metadata.update(**{DEFAULT_METADATA_KEYS.SCALE: self._spacing})
+            elif tuple(existing_scale) != tuple(self._spacing):
+                raise ValueError(
+                    f"Graph metadata `scale` is {tuple(existing_scale)}, which does not match "
+                    f"this operator's `spacing` {tuple(self._spacing)}."
+                )
 
         if t is None:
             time_points = range(labels.shape[0])

--- a/src/tracksdata/nodes/_regionprops.py
+++ b/src/tracksdata/nodes/_regionprops.py
@@ -238,8 +238,15 @@ class RegionPropsNodes(BaseNodesOperator):
         node_op.add_nodes(graph, labels=labels, t=0, intensity_image=fluorescence_image)
         ```
         """
-        if DEFAULT_METADATA_KEYS.SHAPE not in graph.metadata:
+        existing_shape = graph.metadata.get(DEFAULT_METADATA_KEYS.SHAPE)
+        if existing_shape is None:
             graph.metadata.update(**{DEFAULT_METADATA_KEYS.SHAPE: labels.shape})
+        elif tuple(existing_shape) != tuple(labels.shape):
+            LOG.warning(
+                "Graph metadata `shape` is %s, which does not match `labels.shape` %s.",
+                tuple(existing_shape),
+                tuple(labels.shape),
+            )
 
         if self._spacing is not None:
             existing_scale = graph.metadata.get(DEFAULT_METADATA_KEYS.SCALE)

--- a/src/tracksdata/nodes/_test/test_regionprops.py
+++ b/src/tracksdata/nodes/_test/test_regionprops.py
@@ -102,6 +102,44 @@ def test_regionprops_add_nodes_2d() -> None:
     assert areas == [3, 3]
 
 
+def test_regionprops_add_nodes_sets_scale_from_spacing() -> None:
+    """`scale` metadata is set from `spacing` when provided, and left alone otherwise."""
+    labels = np.array([[[1, 1, 0], [1, 0, 2], [0, 2, 2]]], dtype=np.int32)
+
+    graph = RustWorkXGraph()
+    RegionPropsNodes(spacing=(0.5, 0.1)).add_nodes(graph, labels=labels)
+    assert graph.metadata["scale"] == (0.5, 0.1)
+
+    graph_no_spacing = RustWorkXGraph()
+    RegionPropsNodes().add_nodes(graph_no_spacing, labels=labels)
+    assert "scale" not in graph_no_spacing.metadata
+
+
+def test_regionprops_add_nodes_matching_existing_scale_is_a_noop() -> None:
+    """An existing `scale` metadata entry that matches `spacing` is left as-is."""
+    labels = np.array([[[1, 1, 0], [1, 0, 2], [0, 2, 2]]], dtype=np.int32)
+
+    graph = RustWorkXGraph()
+    graph.metadata["scale"] = (0.5, 0.1)
+    RegionPropsNodes(spacing=(0.5, 0.1)).add_nodes(graph, labels=labels)
+    assert graph.metadata["scale"] == (0.5, 0.1)
+
+
+def test_regionprops_add_nodes_raises_on_scale_mismatch() -> None:
+    """A `spacing` that disagrees with the graph's existing `scale` metadata is an error.
+
+    Region properties like `perimeter` are computed using `spacing`, so silently
+    keeping the graph's `scale` would leave it describing a different resolution
+    than the one actually used.
+    """
+    labels = np.array([[[1, 1, 0], [1, 0, 2], [0, 2, 2]]], dtype=np.int32)
+
+    graph = RustWorkXGraph()
+    graph.metadata["scale"] = (1.0, 1.0)
+    with pytest.raises(ValueError, match="does not match"):
+        RegionPropsNodes(spacing=(0.5, 0.1)).add_nodes(graph, labels=labels)
+
+
 def test_regionprops_add_nodes_3d() -> None:
     """Test adding nodes from 3D labels."""
     graph = RustWorkXGraph()


### PR DESCRIPTION
Also adds an enum containing default constant keys for the scale and shape metadata, and some helper functions for manipulating on-disk metadata without loading the graph (mostly for testing purposes).

Technically, I would argue that both scale and shape are the properties of a certain masks column (or even, in the case of scale, of the masks themselves). But, the global property covers most use cases where all masks come from the same segmentation