### PR TITLE
accept numpy integers as node/edge ids

### DIFF
--- a/src/tracksdata/graph/_base_graph.py
+++ b/src/tracksdata/graph/_base_graph.py
@@ -25,6 +25,7 @@ from tracksdata.utils._dtypes import (
 )
 from tracksdata.utils._logging import LOG
 from tracksdata.utils._multiprocessing import multiprocessing_apply
+from tracksdata.utils._numpy_native import is_int_like, to_native
 
 if TYPE_CHECKING:
     import motile
@@ -2276,9 +2277,9 @@ class NodesAccessor:
         NodeInterface
             Interface for accessing the node's attributes.
         """
-        if not isinstance(node_id, int):
+        if not is_int_like(node_id):
             raise ValueError(f"node_id must be an integer, found '{node_id}' of type {type(node_id)}")
-        return NodeInterface(self._graph, node_id)
+        return NodeInterface(self._graph, to_native(node_id))
 
 
 class EdgesAccessor:
@@ -2308,9 +2309,9 @@ class EdgesAccessor:
         EdgeInterface
             Interface for accessing the edge's attributes.
         """
-        if not isinstance(edge_id, int):
+        if not is_int_like(edge_id):
             raise ValueError(f"edge_id must be an integer, found '{edge_id}' of type {type(edge_id)}")
-        return EdgeInterface(self._graph, edge_id)
+        return EdgeInterface(self._graph, to_native(edge_id))
 
 
 class NodeInterface:

--- a/src/tracksdata/graph/_graph_view.py
+++ b/src/tracksdata/graph/_graph_view.py
@@ -13,6 +13,7 @@ from tracksdata.graph._mapped_graph_mixin import MappedGraphMixin
 from tracksdata.graph._rustworkx_graph import IndexedRXGraph, RustWorkXGraph, RXFilter
 from tracksdata.graph.filters._indexed_filter import IndexRXFilter
 from tracksdata.utils._dtypes import AttrSchema
+from tracksdata.utils._numpy_native import is_int_like, to_native, to_native_list
 from tracksdata.utils._signal import (
     emit_node_added_events,
     emit_node_removed_events,
@@ -474,10 +475,7 @@ class GraphView(MappedGraphMixin, RustWorkXGraph):
         ValueError
             If any node_id does not exist in the graph.
         """
-        if hasattr(node_ids, "tolist"):
-            node_ids = node_ids.tolist()
-        else:
-            node_ids = list(node_ids)
+        node_ids = to_native_list(node_ids)
         if len(node_ids) == 0:
             return
 
@@ -701,10 +699,7 @@ class GraphView(MappedGraphMixin, RustWorkXGraph):
         ValueError
             If any edge_id does not exist in the root graph.
         """
-        if hasattr(edge_ids, "tolist"):
-            edge_ids = edge_ids.tolist()
-        else:
-            edge_ids = list(edge_ids)
+        edge_ids = to_native_list(edge_ids)
         if len(edge_ids) == 0:
             return
 
@@ -865,8 +860,8 @@ class GraphView(MappedGraphMixin, RustWorkXGraph):
         single_node = False
         if node_ids is None:
             node_ids = self.node_ids()
-        elif isinstance(node_ids, int):
-            node_ids = [node_ids]
+        elif is_int_like(node_ids):
+            node_ids = [to_native(node_ids)]
             single_node = True
 
         local_node_ids = self._map_to_local(node_ids)
@@ -1074,8 +1069,8 @@ class GraphView(MappedGraphMixin, RustWorkXGraph):
         if node_ids is None:
             node_ids = self.node_ids()
         rx_graph = self.rx_graph
-        if isinstance(node_ids, int):
-            return rx_graph.in_degree(self._map_to_local(node_ids))
+        if is_int_like(node_ids):
+            return rx_graph.in_degree(self._map_to_local(to_native(node_ids)))
         return [rx_graph.in_degree(self._map_to_local(node_id)) for node_id in node_ids]
 
     def out_degree(self, node_ids: list[int] | int | None = None) -> list[int] | int:
@@ -1085,8 +1080,8 @@ class GraphView(MappedGraphMixin, RustWorkXGraph):
         if node_ids is None:
             node_ids = self.node_ids()
         rx_graph = self.rx_graph
-        if isinstance(node_ids, int):
-            return rx_graph.out_degree(self._map_to_local(node_ids))
+        if is_int_like(node_ids):
+            return rx_graph.out_degree(self._map_to_local(to_native(node_ids)))
         return [rx_graph.out_degree(self._map_to_local(node_id)) for node_id in node_ids]
 
     def dividing_nodes(self) -> list[int]:

--- a/src/tracksdata/graph/_rustworkx_graph.py
+++ b/src/tracksdata/graph/_rustworkx_graph.py
@@ -22,6 +22,7 @@ from tracksdata.utils._cache import cache_method
 from tracksdata.utils._dataframe import unpack_array_attrs
 from tracksdata.utils._dtypes import AttrSchema, process_attr_key_args
 from tracksdata.utils._logging import LOG
+from tracksdata.utils._numpy_native import is_int_like, to_native, to_native_list
 from tracksdata.utils._signal import (
     emit_node_added_events,
     emit_node_removed_events,
@@ -179,8 +180,8 @@ class RXFilter(BaseFilter):
         self._graph = graph
         self._attr_comps = attr_comps
 
-        if node_ids is not None and hasattr(node_ids, "tolist"):
-            node_ids = node_ids.tolist()
+        if node_ids is not None:
+            node_ids = to_native_list(node_ids)
 
         self._node_ids = node_ids
         self._include_targets = include_targets
@@ -691,10 +692,7 @@ class RustWorkXGraph(BaseGraph):
         ValueError
             If any node_id does not exist in the graph.
         """
-        if hasattr(node_ids, "tolist"):
-            node_ids = node_ids.tolist()
-        else:
-            node_ids = list(node_ids)
+        node_ids = to_native_list(node_ids)
         if len(node_ids) == 0:
             return
 
@@ -750,10 +748,7 @@ class RustWorkXGraph(BaseGraph):
         ValueError
             If any edge_id does not exist in the graph.
         """
-        if hasattr(edge_ids, "tolist"):
-            edge_ids = edge_ids.tolist()
-        else:
-            edge_ids = list(edge_ids)
+        edge_ids = to_native_list(edge_ids)
         if len(edge_ids) == 0:
             return
         self._bulk_remove_edges_local(edge_ids)
@@ -841,8 +836,8 @@ class RustWorkXGraph(BaseGraph):
         rx_graph = self.rx_graph
         if node_ids is None:
             node_ids = list(rx_graph.node_indices())
-        elif isinstance(node_ids, int):
-            node_ids = [node_ids]
+        elif is_int_like(node_ids):
+            node_ids = [to_native(node_ids)]
             single_node = True
 
         if not return_attrs and attr_keys is not None:
@@ -1434,7 +1429,7 @@ class RustWorkXGraph(BaseGraph):
                     "Often used from `graph.subgraph(edge_attr_filter={'solution': True})`"
                 ) from e
 
-            # Converting to list of int for SQLGraph compatibility (See below)
+            # A list, not the numpy array, so the id remapping below can index into it
             tracklet_ids = tracklet_ids.tolist()
 
             # For the IndexedRXGraph, we need to map the track_node_ids to the external node ids
@@ -1463,9 +1458,7 @@ class RustWorkXGraph(BaseGraph):
                         tracklet_id_map = dict(
                             zip(tracklet_id_map[output_key + "_new"], tracklet_id_map[output_key], strict=True)
                         )
-                        # Ensure that the result is a list of integers (using numpy integer causes issues with SQLGraph)
-                        # Later on, we will make it safe to use numpy integers everywhere for updating attributes.
-                        tracklet_ids = [int(tracklet_id_map.get(tid, tid)) for tid in tracklet_ids]  # type: ignore
+                        tracklet_ids = [tracklet_id_map.get(tid, tid) for tid in tracklet_ids]  # type: ignore
                         # Update the value with the reused IDs
                         id_update_df = id_update_df.with_columns(pl.Series(output_key + "_new", tracklet_ids))
 
@@ -1490,8 +1483,8 @@ class RustWorkXGraph(BaseGraph):
         if node_ids is None:
             node_ids = self.node_ids()
         rx_graph = self.rx_graph
-        if isinstance(node_ids, int):
-            return rx_graph.in_degree(node_ids)
+        if is_int_like(node_ids):
+            return rx_graph.in_degree(to_native(node_ids))
         return [rx_graph.in_degree(node_id) for node_id in node_ids]
 
     def out_degree(self, node_ids: list[int] | int | None = None) -> list[int] | int:
@@ -1501,8 +1494,8 @@ class RustWorkXGraph(BaseGraph):
         if node_ids is None:
             node_ids = self.node_ids()
         rx_graph = self.rx_graph
-        if isinstance(node_ids, int):
-            return rx_graph.out_degree(node_ids)
+        if is_int_like(node_ids):
+            return rx_graph.out_degree(to_native(node_ids))
         return [rx_graph.out_degree(node_id) for node_id in node_ids]
 
     def dividing_nodes(self) -> list[int]:
@@ -2032,10 +2025,7 @@ class IndexedRXGraph(MappedGraphMixin, RustWorkXGraph):
         ValueError
             If any node_id does not exist in the graph.
         """
-        if hasattr(node_ids, "tolist"):
-            node_ids = node_ids.tolist()
-        else:
-            node_ids = list(node_ids)
+        node_ids = to_native_list(node_ids)
         if len(node_ids) == 0:
             return
 

--- a/src/tracksdata/graph/_sql_graph.py
+++ b/src/tracksdata/graph/_sql_graph.py
@@ -42,6 +42,7 @@ from tracksdata.utils._dtypes import (
     sqlalchemy_type_to_polars_dtype,
 )
 from tracksdata.utils._logging import LOG
+from tracksdata.utils._numpy_native import is_int_like, to_native, to_native_list
 from tracksdata.utils._signal import (
     emit_node_added_events,
     emit_node_removed_events,
@@ -65,11 +66,7 @@ def _data_numpy_to_native(data: dict[str, Any]) -> None:
     """
     Convert numpy scalars to native Python scalars in place.
 
-    Database drivers do not know about numpy scalar types. ``sqlite3``, for example,
-    falls back to the buffer protocol and stores ``np.int64(7)`` as its raw
-    little-endian byte buffer (a BLOB), silently corrupting a column declared as
-    ``BIGINT``. Numpy floats and strings happen to survive because they subclass
-    their Python counterparts, which makes the corruption look selective.
+    See :func:`tracksdata.utils._numpy_native.to_native` for why drivers need this.
 
     Parameters
     ----------
@@ -77,10 +74,7 @@ def _data_numpy_to_native(data: dict[str, Any]) -> None:
         The data to convert. Modified in place.
     """
     for k, v in data.items():
-        # `np.generic` is the base class of every numpy scalar, and excludes
-        # (0-dim) arrays, which must be passed through untouched.
-        if isinstance(v, np.generic):
-            data[k] = v.item()
+        data[k] = to_native(v)
 
 
 def _resolve_attr_filter_column(
@@ -113,7 +107,11 @@ def _to_sql_clause(f: Filter, table: type[DeclarativeBase]) -> Any:
     struct-field comparisons resolve to the flat physical column.
     """
     if isinstance(f, AttrComparison):
-        return f.op(_resolve_attr_filter_column(table, f), f.other)
+        # The compared value is bound as a SQL parameter, so numpy scalars (including
+        # the sequence of them that `is_in` takes) must be converted first.
+        other = f.other
+        other = to_native_list(other) if isinstance(other, list | tuple | np.ndarray) else to_native(other)
+        return f.op(_resolve_attr_filter_column(table, f), other)
 
     assert isinstance(f, AttrFilter)
     if f.op == "not":
@@ -167,9 +165,7 @@ class _SQLIDSet:
         *,
         occurrences: int = 1,
     ) -> None:
-        if hasattr(ids, "tolist"):
-            ids = ids.tolist()
-        self._ids: list[int] = list(ids)
+        self._ids: list[int] = to_native_list(ids)
         # Hold the engine, not the graph, so this set does not participate in
         # the graph -> SQLFilter -> _SQLIDSet -> graph reference cycle.
         # Otherwise the scratch table would only be dropped after Python's
@@ -1085,10 +1081,7 @@ class SQLGraph(BaseGraph):
         ValueError
             If any node_id does not exist in the graph.
         """
-        if hasattr(node_ids, "tolist"):
-            node_ids = node_ids.tolist()
-        else:
-            node_ids = list(node_ids)
+        node_ids = to_native_list(node_ids)
 
         if len(node_ids) == 0:
             return
@@ -1240,10 +1233,10 @@ class SQLGraph(BaseGraph):
         [add_overlap][tracksdata.graph.SQLGraph.add_overlap]:
             Add a single overlap to the graph.
         """
-        if hasattr(overlaps, "tolist"):
-            overlaps = overlaps.tolist()
-
-        overlaps = [{"source_id": int(source_id), "target_id": int(target_id)} for source_id, target_id in overlaps]
+        # `overlaps` is a nested sequence, so each id is converted individually
+        overlaps = [
+            {"source_id": to_native(source_id), "target_id": to_native(target_id)} for source_id, target_id in overlaps
+        ]
         self._chunked_sa_write(Session.bulk_insert_mappings, overlaps, self.Overlap)
 
     def overlaps(
@@ -1260,8 +1253,8 @@ class SQLGraph(BaseGraph):
         filtered in Polars afterwards to avoid a quadratic blow-up of bound
         parameters.
         """
-        if hasattr(node_ids, "tolist"):
-            node_ids = node_ids.tolist()
+        if node_ids is not None:
+            node_ids = to_native_list(node_ids)
 
         with Session(self._engine) as session:
             base_query = session.query(self.Overlap.source_id, self.Overlap.target_id)
@@ -1330,14 +1323,15 @@ class SQLGraph(BaseGraph):
         """
         single_node = False
         filter_node_ids: list[int] | None
-        if isinstance(node_ids, int):
-            node_ids = [node_ids]
+        if is_int_like(node_ids):
+            node_ids = [to_native(node_ids)]
             filter_node_ids = node_ids
             single_node = True
         elif node_ids is None:
             node_ids = self.node_ids()
             filter_node_ids = None
         else:
+            node_ids = to_native_list(node_ids)
             filter_node_ids = node_ids
 
         if isinstance(attr_keys, str):
@@ -2036,8 +2030,7 @@ class SQLGraph(BaseGraph):
                 LOG.info("No ids to update, skipping")
                 return
 
-            if hasattr(ids, "tolist"):
-                ids = ids.tolist()
+            ids = to_native_list(ids)
 
         # Handle array values with bulk_update_mappings
         schemas = self._attr_schemas_for_table(table_class)
@@ -2255,8 +2248,8 @@ class SQLGraph(BaseGraph):
     ) -> list[int] | int:
         edge_key_col = getattr(self.Edge, node_key)
 
-        if isinstance(node_ids, int):
-            stmt = sa.select(sa.func.count()).where(edge_key_col == node_ids)
+        if is_int_like(node_ids):
+            stmt = sa.select(sa.func.count()).where(edge_key_col == to_native(node_ids))
             with Session(self._engine) as session:
                 return int(session.execute(stmt).scalar())
 
@@ -2267,6 +2260,7 @@ class SQLGraph(BaseGraph):
             if node_ids is None:
                 degree.update(session.execute(base_stmt).all())
             else:
+                node_ids = to_native_list(node_ids)
                 # Chunk the IN(...) so the bound-parameter count stays below
                 # the backend's limit (notably SQLite's
                 # ``SQLITE_MAX_VARIABLE_NUMBER``). Each chunk's group-by result
@@ -2590,7 +2584,7 @@ class SQLGraph(BaseGraph):
         Check if the graph has a node with the given id.
         """
         with Session(self._engine) as session:
-            return session.scalar(sa.sql.expression.exists().where(self.Node.node_id == node_id).select())
+            return session.scalar(sa.sql.expression.exists().where(self.Node.node_id == to_native(node_id)).select())
 
     def has_edge(self, source_id: int, target_id: int) -> bool:
         """
@@ -2599,7 +2593,7 @@ class SQLGraph(BaseGraph):
         with Session(self._engine) as session:
             return (
                 session.query(self.Edge)
-                .filter(self.Edge.source_id == source_id, self.Edge.target_id == target_id)
+                .filter(self.Edge.source_id == to_native(source_id), self.Edge.target_id == to_native(target_id))
                 .count()
                 > 0
             )
@@ -2611,7 +2605,7 @@ class SQLGraph(BaseGraph):
         with Session(self._engine) as session:
             edge_id = (
                 session.query(self.Edge.edge_id)
-                .filter(self.Edge.source_id == source_id, self.Edge.target_id == target_id)
+                .filter(self.Edge.source_id == to_native(source_id), self.Edge.target_id == to_native(target_id))
                 .scalar()
             )
             if edge_id is None:
@@ -2632,10 +2626,7 @@ class SQLGraph(BaseGraph):
         ValueError
             If any edge_id does not exist in the graph.
         """
-        if hasattr(edge_ids, "tolist"):
-            edge_ids = edge_ids.tolist()
-        else:
-            edge_ids = list(edge_ids)
+        edge_ids = to_native_list(edge_ids)
 
         if len(edge_ids) == 0:
             return

--- a/src/tracksdata/graph/_test/test_graph_backends.py
+++ b/src/tracksdata/graph/_test/test_graph_backends.py
@@ -172,6 +172,113 @@ def test_valid_attr_keys_are_not_rejected(graph_backend: BaseGraph) -> None:
     assert graph_backend.filter(EdgeAttr("w") == 1.0).edge_ids() == [ids["e"]]
 
 
+def _numpy_id_graph(graph: BaseGraph) -> dict[str, int]:
+    """A 3-node / 2-edge chain with one int node attr and one int edge attr."""
+    graph.add_node_attr_key("area", dtype=pl.Float64, default_value=0.0)
+    graph.add_node_attr_key("label", dtype=pl.Int64, default_value=0)
+    graph.add_edge_attr_key("rank", dtype=pl.Int64, default_value=0)
+    a = graph.add_node({"t": 0, "area": 1.0, "label": 10})
+    b = graph.add_node({"t": 1, "area": 2.0, "label": 20})
+    c = graph.add_node({"t": 2, "area": 3.0, "label": 30})
+    e_ab = graph.add_edge(a, b, {"rank": 0})
+    e_bc = graph.add_edge(b, c, {"rank": 1})
+    graph.add_overlap(b, c)
+    return {"a": a, "b": b, "c": c, "e_ab": e_ab, "e_bc": e_bc}
+
+
+# `np.int64` is not a subclass of `int`, and numpy integers leak out of nearly every
+# numpy / polars / scikit-image operation, so they reach the graph API constantly.
+# Database drivers do not know them: `sqlite3` falls back to the buffer protocol and
+# binds `np.int64(7)` as an 8-byte BLOB, so `node_id == np.int64(7)` matched nothing and
+# lookups silently reported "not found" instead of raising. Every read path below must
+# therefore give the same answer for a Python int and for the equal numpy integer.
+_NUMPY_ID_ACCESSORS: dict[str, Callable[[BaseGraph, dict[str, int], Callable[[int], Any]], Any]] = {
+    "has_node": lambda g, i, c: g.has_node(c(i["a"])),
+    "has_edge": lambda g, i, c: g.has_edge(c(i["a"]), c(i["b"])),
+    "edge_id": lambda g, i, c: g.edge_id(c(i["a"]), c(i["b"])),
+    "successors(scalar)": lambda g, i, c: g.successors(c(i["a"])),
+    "successors(list)": lambda g, i, c: g.successors([c(i["a"])]),
+    "predecessors(scalar)": lambda g, i, c: g.predecessors(c(i["b"])),
+    "predecessors(list)": lambda g, i, c: g.predecessors([c(i["b"])]),
+    "in_degree(scalar)": lambda g, i, c: g.in_degree(c(i["b"])),
+    "in_degree(list)": lambda g, i, c: g.in_degree([c(i["b"])]),
+    "out_degree(list)": lambda g, i, c: g.out_degree([c(i["a"])]),
+    "filter(node_ids).node_ids": lambda g, i, c: sorted(g.filter(node_ids=[c(i["a"])]).node_ids()),
+    "filter(node_ids).edge_ids": lambda g, i, c: sorted(g.filter(node_ids=[c(i["a"]), c(i["b"])]).edge_ids()),
+    "filter(node_ids).node_attrs": lambda g, i, c: (
+        g.filter(node_ids=[c(i["a"])]).node_attrs(attr_keys=["t"]).to_dicts()
+    ),
+    "filter(node_ids).subgraph": lambda g, i, c: sorted(
+        g.filter(node_ids=[c(i["a"]), c(i["b"])]).subgraph().node_ids()
+    ),
+    "filter(NodeAttr == value)": lambda g, i, c: sorted(g.filter(NodeAttr("label") == c(20)).node_ids()),
+    "filter(EdgeAttr == value)": lambda g, i, c: sorted(g.filter(EdgeAttr("rank") == c(1)).edge_ids()),
+    "filter(NodeAttr is_in values)": lambda g, i, c: sorted(
+        g.filter(NodeAttr("label").is_in([c(10), c(20)])).node_ids()
+    ),
+    "nodes[id]": lambda g, i, c: g.nodes[c(i["a"])]["area"],
+    "edges[id]": lambda g, i, c: g.edges[c(i["e_ab"])]["rank"],
+    # `overlaps` keeps only pairs with *both* endpoints in `node_ids`
+    "overlaps": lambda g, i, c: g.overlaps([c(i["b"]), c(i["c"])]),
+}
+
+
+@pytest.mark.parametrize(
+    "accessor",
+    list(_NUMPY_ID_ACCESSORS.values()),
+    ids=list(_NUMPY_ID_ACCESSORS.keys()),
+)
+def test_numpy_integer_ids_read_paths(
+    graph_backend: BaseGraph,
+    accessor: Callable[[BaseGraph, dict[str, int], Callable[[int], Any]], Any],
+) -> None:
+    """A numpy integer id or filter value behaves exactly like the equal Python int."""
+    ids = _numpy_id_graph(graph_backend)
+
+    expected = accessor(graph_backend, ids, int)
+    assert accessor(graph_backend, ids, np.int64) == expected
+
+
+@pytest.mark.parametrize("cast", [int, np.int64], ids=["int", "np.int64"])
+def test_numpy_integer_ids_write_paths(graph_backend: BaseGraph, cast: Callable[[int], Any]) -> None:
+    """Mutating calls take effect whether the id is a Python int or a numpy integer."""
+    ids = _numpy_id_graph(graph_backend)
+
+    graph_backend.update_node_attrs(node_ids=[cast(ids["a"])], attrs={"area": 9.0})
+    assert graph_backend.nodes[ids["a"]]["area"] == 9.0
+
+    graph_backend.update_edge_attrs(edge_ids=[cast(ids["e_ab"])], attrs={"rank": 7})
+    assert graph_backend.edges[ids["e_ab"]]["rank"] == 7
+
+    new_edge = graph_backend.add_edge(cast(ids["a"]), cast(ids["c"]), {"rank": 2})
+    assert graph_backend.has_edge(ids["a"], ids["c"])
+
+    graph_backend.remove_edge(edge_id=cast(new_edge))
+    assert not graph_backend.has_edge(ids["a"], ids["c"])
+
+    graph_backend.remove_edge(cast(ids["a"]), cast(ids["b"]))
+    assert not graph_backend.has_edge(ids["a"], ids["b"])
+
+    graph_backend.remove_node(cast(ids["a"]))
+    assert not graph_backend.has_node(ids["a"])
+
+    graph_backend.bulk_remove_nodes([cast(ids["b"])])
+    assert not graph_backend.has_node(ids["b"])
+
+
+def test_numpy_integer_ids_bulk_add(graph_backend: BaseGraph) -> None:
+    """Bulk adds accept numpy integer ids and store them as native integers."""
+    graph_backend.add_edge_attr_key("rank", dtype=pl.Int64, default_value=0)
+    node_ids = graph_backend.bulk_add_nodes([{"t": 0}, {"t": 1}])
+
+    graph_backend.bulk_add_edges([{"source_id": np.int64(node_ids[0]), "target_id": np.int64(node_ids[1]), "rank": 0}])
+
+    assert graph_backend.has_edge(node_ids[0], node_ids[1])
+    edge_df = graph_backend.edge_attrs(attr_keys=[DEFAULT_ATTR_KEYS.EDGE_SOURCE, DEFAULT_ATTR_KEYS.EDGE_TARGET])
+    assert edge_df[DEFAULT_ATTR_KEYS.EDGE_SOURCE].to_list() == [node_ids[0]]
+    assert edge_df[DEFAULT_ATTR_KEYS.EDGE_TARGET].to_list() == [node_ids[1]]
+
+
 def test_add_node(graph_backend: BaseGraph) -> None:
     """Test adding nodes with various attributes."""
 

--- a/src/tracksdata/utils/_numpy_native.py
+++ b/src/tracksdata/utils/_numpy_native.py
@@ -1,0 +1,64 @@
+"""Coercion of numpy scalars into the native Python scalars that other libraries understand."""
+
+from collections.abc import Sequence
+from typing import Any
+
+import numpy as np
+
+
+def is_int_like(value: Any) -> bool:
+    """
+    Whether ``value`` is a single integer, either a Python ``int`` or a numpy integer.
+
+    ``np.int64`` is not a subclass of ``int``, so a plain ``isinstance(value, int)``
+    check rejects the numpy integers that come out of nearly every numpy or polars
+    operation. Use this wherever a scalar id must be told apart from a sequence of ids.
+    """
+    return isinstance(value, int | np.integer)
+
+
+def to_native(value: Any) -> Any:
+    """
+    Return the native Python equivalent of a numpy scalar, or ``value`` unchanged.
+
+    Database drivers do not know about numpy's scalar types. ``sqlite3``, for example,
+    falls back to the buffer protocol and binds ``np.int64(7)`` as its raw little-endian
+    byte buffer (a BLOB), which never compares equal to an ``INTEGER`` column, so queries
+    silently match no rows instead of raising. Numpy floats and strings happen to survive
+    because they subclass their Python counterparts, which makes the corruption look
+    selective.
+
+    Parameters
+    ----------
+    value : Any
+        The value to convert. Non-numpy values are returned as-is.
+
+    Returns
+    -------
+    Any
+        ``value.item()`` for numpy scalars, otherwise ``value``.
+    """
+    # `np.generic` is the base class of every numpy scalar, and excludes (0-dim)
+    # arrays, which must be passed through untouched.
+    if isinstance(value, np.generic):
+        return value.item()
+    return value
+
+
+def to_native_list(values: Sequence[Any] | np.ndarray) -> list[Any]:
+    """
+    Return ``values`` as a list with every numpy scalar converted to native Python.
+
+    Parameters
+    ----------
+    values : Sequence[Any] | np.ndarray
+        The values to convert.
+
+    Returns
+    -------
+    list[Any]
+        A new list of native Python scalars.
+    """
+    if isinstance(values, np.ndarray):
+        return values.tolist()
+    return [to_native(v) for v in values]


### PR DESCRIPTION
Closes #338 

`SQLGraph` silently gave wrong answers when passed a numpy integer instead of a Python `int`:

```python
g.has_node(node_id)              # True
g.has_node(np.int64(node_id))    # False
```

`np.int64` is not a subclass of `int`, and `sqlite3` doesn't know the type — it falls back to the buffer protocol and binds it as an 8-byte BLOB, which never compares equal to an INTEGER column. So lookups returned "not found" instead of raising. `RustWorkXGraph` accepted the same input fine, so the two backends disagreed. Since numpy integers come out of almost every numpy/polars call, callers were having to wrap ids in `int()` everywhere.

Affected `SQLGraph` paths, all silently wrong rather than raising: `has_node`, `has_edge`, `edge_id`, `successors`/`predecessors`, `in_degree`/`out_degree`, `filter(node_ids=...)`, and attribute filters like `NodeAttr("t") == np.int64(1)`.

## Changes

- New `utils/_numpy_native.py` with `is_int_like` / `to_native` / `to_native_list`.
- `SQLGraph` converts ids and filter values before they're bound as SQL parameters.
- `isinstance(node_ids, int)` scalar-vs-sequence checks now use `is_int_like`, so a numpy scalar isn't mistaken for a sequence.
- `graph.nodes[id]` / `graph.edges[id]` accept numpy integers.
- Replaced 7 copies of `hasattr(x, "tolist")` with `to_native_list`, which also handles a plain list of numpy scalars (the old form only handled arrays).

## Tests

`test_numpy_integer_ids_*` in `test_graph_backends.py` run against all three backends: 20 read paths asserted to give the same answer for `int` and `np.int64`, plus the write and bulk-add paths. 23 of them failed before this change.
